### PR TITLE
fix: JSON null 配列の正規化（Go/フロント両層）+ serve ログ + Makefile gox 探索改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,12 @@ clean:
 release: gen frontend verify-frontend
 	@GOX_BIN="$$(command -v gox 2>/dev/null || true)"; \
 	if [ -z "$$GOX_BIN" ]; then \
-		GOX_BIN="$$( $(GO) env GOPATH )/bin/gox"; \
+		GOPATH_FIRST="$$( $(GO) env GOPATH )"; \
+		GOPATH_FIRST="$${GOPATH_FIRST%%:*}"; \
+		GOX_BIN="$$GOPATH_FIRST/bin/gox"; \
 	fi; \
 	if [ ! -x "$$GOX_BIN" ]; then \
-		echo "ERROR: gox not found (checked PATH and $$($(GO) env GOPATH)/bin/gox); install via 'go install github.com/mitchellh/gox@latest'" >&2; \
+		echo "ERROR: gox not found (checked PATH and $$GOX_BIN); install via 'go install github.com/mitchellh/gox@latest'" >&2; \
 		exit 1; \
 	fi; \
 	"$$GOX_BIN" -osarch "$(GOX_TARGETS)" -output "$(BIN_DIR)/{{.Dir}}_{{.OS}}_{{.Arch}}"

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,9 @@ verify-frontend:
 #   `-o erdm .` で実体を必ず作る（README の "make build" と整合させる）。
 # --------------------------------------------------------------------------
 build: gen frontend verify-frontend
-	@echo ">> go build"
+	@echo ">> go build -> ./erdm"
 	@$(GO) build -o erdm .
+	@echo ">> Run: ./erdm serve ...   (bin/erdm_linux_amd64 is from 'make release', not updated by this target)"
 
 # --------------------------------------------------------------------------
 # フロントエンドの単体テスト (Vitest, タスク 7.8)
@@ -122,11 +123,15 @@ clean:
 # クロスコンパイル成果物（旧 build.sh 相当）。gox 必須。
 # --------------------------------------------------------------------------
 release: gen frontend verify-frontend
-	@command -v gox >/dev/null 2>&1 || { \
-		echo "ERROR: gox not found in PATH; install via 'go install github.com/mitchellh/gox@latest'" >&2; \
+	@GOX_BIN="$$(command -v gox 2>/dev/null || true)"; \
+	if [ -z "$$GOX_BIN" ]; then \
+		GOX_BIN="$$( $(GO) env GOPATH )/bin/gox"; \
+	fi; \
+	if [ ! -x "$$GOX_BIN" ]; then \
+		echo "ERROR: gox not found (checked PATH and $$($(GO) env GOPATH)/bin/gox); install via 'go install github.com/mitchellh/gox@latest'" >&2; \
 		exit 1; \
-	}
-	@gox -osarch "$(GOX_TARGETS)" -output "$(BIN_DIR)/{{.Dir}}_{{.OS}}_{{.Arch}}"
+	fi; \
+	"$$GOX_BIN" -osarch "$(GOX_TARGETS)" -output "$(BIN_DIR)/{{.Dir}}_{{.OS}}_{{.Arch}}"
 
 # --------------------------------------------------------------------------
 # tools: tools/tools.go を経由した依存解決のスモークテスト

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -74,6 +74,47 @@ describe('getSchema', () => {
     expect((err as ApiError).status).toBe(502)
     expect((err as ApiError).code).toBe('http_error')
   })
+
+  it('normalizes null JSON array fields (Go nil slices) so UI can call .join safely', async () => {
+    const raw = {
+      Title: 't',
+      Groups: null,
+      Tables: [
+        {
+          Name: 'users',
+          LogicalName: '',
+          Columns: [
+            {
+              Name: 'id',
+              LogicalName: '',
+              Type: 'int',
+              AllowNull: false,
+              IsUnique: false,
+              IsPrimaryKey: true,
+              Default: '',
+              Comments: null,
+              WithoutErd: false,
+              FK: null,
+              IndexRefs: null,
+            },
+          ],
+          PrimaryKeys: null,
+          Indexes: null,
+          Groups: null,
+        },
+      ],
+    }
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(raw), { status: 200 }))
+    const got = await getSchema()
+    expect(got.Groups).toEqual([])
+    const tbl = got.Tables[0]
+    expect(tbl?.Groups).toEqual([])
+    expect(tbl?.PrimaryKeys).toEqual([])
+    expect(tbl?.Indexes).toEqual([])
+    const col = tbl?.Columns[0]
+    expect(col?.Comments).toEqual([])
+    expect(col?.IndexRefs).toEqual([])
+  })
 })
 
 describe('putSchema', () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,7 +14,7 @@
 //   - `PUT /api/layout` は `application/json`（Go 側は `json.Decode`）。
 //   - 認証ヘッダ・CORS 対応は対象外（`erdm serve` はローカル限定 = 127.0.0.1 既定）。
 
-import type { DdlDialect, Layout, Schema } from '../model'
+import { normalizeSchema, type DdlDialect, type Layout, type Schema } from '../model'
 
 // API ベース URL。Vite の dev サーバではプロキシ経由（vite.config.ts）、
 // 本番ビルドでは Go バイナリの SPA 配信と同一オリジンで動作する。
@@ -85,7 +85,7 @@ async function throwIfNotOk(res: Response): Promise<void> {
 export async function getSchema(): Promise<Schema> {
   const res = await fetch(`${API_BASE}/schema`, { method: 'GET' })
   await throwIfNotOk(res)
-  return (await res.json()) as Schema
+  return normalizeSchema((await res.json()) as Schema)
 }
 
 // putSchema は PUT /api/schema にシリアライズ済み `.erdm` テキストを送る

--- a/frontend/src/model/index.ts
+++ b/frontend/src/model/index.ts
@@ -1,4 +1,5 @@
 // 公開境界: サーバ JSON ⇄ 内部 TS モデルの型定義をまとめて再エクスポートする
 // （design.md §C11）。実体は `./types` に集約しており、本ファイルは
 // `import { Schema } from '../model'` 形式の参照点として機能する。
+export * from './normalize'
 export * from './types'

--- a/frontend/src/model/normalize.ts
+++ b/frontend/src/model/normalize.ts
@@ -1,0 +1,49 @@
+// Go の encoding/json が nil スライスを JSON null と書き出す場合や、古い下書き JSON
+// により配列フィールドが null になる場合に、UI・シリアライザが安全に動くよう
+// 正規化する（TableForm / ColumnForm の .join など）。
+
+import type { Column, Index, Schema, Table } from './types'
+
+function stringArray(v: unknown): string[] {
+  return Array.isArray(v) ? (v as string[]) : []
+}
+
+function intArray(v: unknown): number[] {
+  return Array.isArray(v) ? (v as number[]) : []
+}
+
+function normalizeIndex(i: Index): Index {
+  return {
+    ...i,
+    Columns: stringArray(i.Columns),
+  }
+}
+
+function normalizeColumn(c: Column): Column {
+  return {
+    ...c,
+    Comments: stringArray(c.Comments),
+    IndexRefs: intArray(c.IndexRefs),
+  }
+}
+
+function normalizeTable(t: Table): Table {
+  const cols = Array.isArray(t.Columns) ? t.Columns : []
+  return {
+    ...t,
+    Columns: cols.map(normalizeColumn),
+    PrimaryKeys: intArray(t.PrimaryKeys),
+    Indexes: Array.isArray(t.Indexes) ? t.Indexes.map(normalizeIndex) : [],
+    Groups: stringArray(t.Groups),
+  }
+}
+
+/** API / localStorage から受け取ったスキーマを内部不変条件に合わせて整形する。 */
+export function normalizeSchema(s: Schema): Schema {
+  const tables = Array.isArray(s.Tables) ? s.Tables : []
+  return {
+    ...s,
+    Tables: tables.map(normalizeTable),
+    Groups: stringArray(s.Groups),
+  }
+}

--- a/frontend/src/storage/draft.ts
+++ b/frontend/src/storage/draft.ts
@@ -15,7 +15,7 @@
 // と未保存（null）を `null` で同一視する（呼び出し側はサーバ取得値にフォール
 // バックすればよい）。
 
-import type { Schema } from '../model'
+import { normalizeSchema, type Schema } from '../model'
 
 // localStorage キー。SPA 内で唯一の下書きを表す。
 const DRAFT_KEY = 'erdm-draft'
@@ -38,7 +38,7 @@ export function loadDraft(): Schema | null {
     return null
   }
   try {
-    return JSON.parse(raw) as Schema
+    return normalizeSchema(JSON.parse(raw) as Schema)
   } catch (err) {
     console.warn('Failed to parse draft from localStorage:', err)
     return null

--- a/internal/parser/convert.go
+++ b/internal/parser/convert.go
@@ -2,6 +2,21 @@ package parser
 
 import "github.com/unok/erdm/internal/model"
 
+// copyStrings / copyInts は JSON エンコード時に nil スライスが null になるのを避ける。
+// encoding/json は nil スライスを null と書き出し、SPA 側で array 前提の .join が
+// 失敗する（空の Groups / Comments など）。
+func copyStrings(s []string) []string {
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}
+
+func copyInts(s []int) []int {
+	out := make([]int, len(s))
+	copy(out, s)
+	return out
+}
+
 // toSchema は parserBuilder の中間表現を新しい model.Schema へ変換する。
 // 旧 erdm.go の ErdM/Table/Column フィールド名から新モデル名への対応は
 // design.md §テンプレートと新モデルのフィールド対応表 に従う:
@@ -36,16 +51,16 @@ func (p *parserBuilder) convertTable(t *parserTable) model.Table {
 	for ci := range t.columns {
 		cols = append(cols, convertColumn(&t.columns[ci]))
 	}
-	pks := append([]int(nil), t.primaryKeys...)
+	pks := copyInts(t.primaryKeys)
 	indexes := make([]model.Index, 0, len(t.indexes))
 	for _, idx := range t.indexes {
 		indexes = append(indexes, model.Index{
 			Name:     idx.title,
-			Columns:  append([]string(nil), idx.columns...),
+			Columns:  copyStrings(idx.columns),
 			IsUnique: idx.isUnique,
 		})
 	}
-	groups := append([]string(nil), t.groups...)
+	groups := copyStrings(t.groups)
 	return model.Table{
 		Name:        t.titleReal,
 		LogicalName: t.title,
@@ -75,10 +90,10 @@ func convertColumn(c *parserColumn) model.Column {
 		IsUnique:     c.isUnique,
 		IsPrimaryKey: c.isPrimaryKey,
 		Default:      c.defaultExpr,
-		Comments:     append([]string(nil), c.comments...),
+		Comments:     copyStrings(c.comments),
 		WithoutErd:   c.withoutErd,
 		FK:           fk,
-		IndexRefs:    append([]int(nil), c.indexIndexes...),
+		IndexRefs:    copyInts(c.indexIndexes),
 	}
 }
 

--- a/internal/parser/json_nil_slices_test.go
+++ b/internal/parser/json_nil_slices_test.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Go の encoding/json は nil スライスを null と書き出す。空の Groups / Comments などで
+// SPA が .join を呼ぶと落ちるため、パーサ出力では空でも非 nil スライスに正規化する。
+func TestMarshalSchemaNoNullSlicesForEmptyTableGroupsAndComments(t *testing.T) {
+	src := []byte("# Title: t\n" +
+		"users / \"Users\"\n" +
+		"    +id [bigserial][NN][U]\n")
+	s, perr := Parse(src)
+	if perr != nil {
+		t.Fatal(perr)
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(b)
+	if strings.Contains(js, `"Groups":null`) {
+		t.Fatalf("expected no null Groups slice in JSON: %s", js)
+	}
+	if strings.Contains(js, `"Comments":null`) {
+		t.Fatalf("expected no null Comments slice in JSON: %s", js)
+	}
+	if strings.Contains(js, `"PrimaryKeys":null`) {
+		t.Fatalf("expected no null PrimaryKeys slice in JSON: %s", js)
+	}
+	if strings.Contains(js, `"IndexRefs":null`) {
+		t.Fatalf("expected no null IndexRefs slice in JSON: %s", js)
+	}
+}

--- a/internal/server/serve_console.go
+++ b/internal/server/serve_console.go
@@ -2,19 +2,21 @@ package server
 
 import (
 	"log"
-	"net"
 	"net/http"
-	"strconv"
 	"time"
 )
 
-// listenBaseURL はブラウザで開く際の http:// ベース URL を組み立てる。
-// IPv6 のリッスンアドレスは net.JoinHostPort がホスト部を角括弧で囲む。
-func listenBaseURL(host string, port int) string {
-	return "http://" + net.JoinHostPort(host, strconv.Itoa(port))
+// listenBaseURL は実際にバインドされたリッスンアドレス（host:port）から
+// ブラウザで開く http:// ベース URL を組み立てる。
+// net.Listener.Addr().String() は IPv6 のホスト部を角括弧で囲んで返すため
+// そのまま連結できる。
+func listenBaseURL(addr string) string {
+	return "http://" + addr
 }
 
 // logStartup は serve モード起動直後に設定概要を標準エラーへ出す。
+// addr にはリスナーの実バインドアドレス（net.Listener.Addr().String()）を渡す。
+// --port=0（OS 割当）の場合も実際に割り当てられたポートが表示される。
 func (s *Server) logStartup(addr string) {
 	mode := "read-write (PUT /api/schema, PUT /api/layout enabled)"
 	if s.cfg.NoWrite {
@@ -25,7 +27,7 @@ func (s *Server) logStartup(addr string) {
 		dot = "available (SVG/PNG export)"
 	}
 	log.Printf("erdm serve: Web UI + REST API")
-	log.Printf("erdm serve: listen %s (base URL %s)", addr, listenBaseURL(s.cfg.Listen, s.cfg.Port))
+	log.Printf("erdm serve: listen %s (base URL %s)", addr, listenBaseURL(addr))
 	log.Printf("erdm serve: schema %s", s.cfg.SchemaPath)
 	log.Printf("erdm serve: layout %s", s.layoutPath)
 	log.Printf("erdm serve: mode %s", mode)
@@ -44,14 +46,29 @@ func (s *Server) withAccessLog(next http.Handler) http.Handler {
 	})
 }
 
-// loggingResponseWriter は WriteHeader で渡された応答ステータスを記録する。
-// Write のみで本文を返すハンドラは既定 200 として記録する。
+// loggingResponseWriter は実際にクライアントへ送られた応答ステータスを記録する。
+// net/http は最初の WriteHeader（または Write による暗黙の 200）以降の
+// WriteHeader を無視するため、こちらも最初の 1 回だけを記録して
+// 「送っていないステータスをログする」ズレを防ぐ。
 type loggingResponseWriter struct {
 	http.ResponseWriter
-	status int
+	status      int
+	wroteHeader bool
 }
 
 func (w *loggingResponseWriter) WriteHeader(code int) {
-	w.status = code
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		w.status = code
+	}
 	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *loggingResponseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		// Write が先行した場合、net/http は暗黙に 200 を送出する。
+		w.wroteHeader = true
+		w.status = http.StatusOK
+	}
+	return w.ResponseWriter.Write(b)
 }

--- a/internal/server/serve_console.go
+++ b/internal/server/serve_console.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// listenBaseURL はブラウザで開く際の http:// ベース URL を組み立てる。
+// IPv6 のリッスンアドレスは net.JoinHostPort がホスト部を角括弧で囲む。
+func listenBaseURL(host string, port int) string {
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+// logStartup は serve モード起動直後に設定概要を標準エラーへ出す。
+func (s *Server) logStartup(addr string) {
+	mode := "read-write (PUT /api/schema, PUT /api/layout enabled)"
+	if s.cfg.NoWrite {
+		mode = "read-only (--no-write)"
+	}
+	dot := "unavailable (SVG/PNG export returns 503)"
+	if s.cfg.HasDot {
+		dot = "available (SVG/PNG export)"
+	}
+	log.Printf("erdm serve: Web UI + REST API")
+	log.Printf("erdm serve: listen %s (base URL %s)", addr, listenBaseURL(s.cfg.Listen, s.cfg.Port))
+	log.Printf("erdm serve: schema %s", s.cfg.SchemaPath)
+	log.Printf("erdm serve: layout %s", s.layoutPath)
+	log.Printf("erdm serve: mode %s", mode)
+	log.Printf("erdm serve: graphviz dot %s", dot)
+	log.Printf("erdm serve: access log on (stderr)")
+}
+
+// withAccessLog はリクエストごとにメソッド・パス・ステータス・処理時間・クライアントをログする。
+func (s *Server) withAccessLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		lw := &loggingResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(lw, r)
+		log.Printf("erdm serve: %s %s %d %s %s",
+			r.Method, r.URL.RequestURI(), lw.status, time.Since(start).Round(time.Microsecond), r.RemoteAddr)
+	})
+}
+
+// loggingResponseWriter は WriteHeader で渡された応答ステータスを記録する。
+// Write のみで本文を返すハンドラは既定 200 として記録する。
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *loggingResponseWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}

--- a/internal/server/serve_console_test.go
+++ b/internal/server/serve_console_test.go
@@ -1,0 +1,27 @@
+package server
+
+import "testing"
+
+func TestListenBaseURL_IPv4(t *testing.T) {
+	got := listenBaseURL("127.0.0.1", 8080)
+	want := "http://127.0.0.1:8080"
+	if got != want {
+		t.Fatalf("listenBaseURL: got %q, want %q", got, want)
+	}
+}
+
+func TestListenBaseURL_IPv6(t *testing.T) {
+	got := listenBaseURL("::1", 3123)
+	want := "http://[::1]:3123"
+	if got != want {
+		t.Fatalf("listenBaseURL: got %q, want %q", got, want)
+	}
+}
+
+func TestListenBaseURL_AllInterfaces(t *testing.T) {
+	got := listenBaseURL("0.0.0.0", 3123)
+	want := "http://0.0.0.0:3123"
+	if got != want {
+		t.Fatalf("listenBaseURL: got %q, want %q", got, want)
+	}
+}

--- a/internal/server/serve_console_test.go
+++ b/internal/server/serve_console_test.go
@@ -1,17 +1,22 @@
 package server
 
-import "testing"
+import (
+	"net/http/httptest"
+	"testing"
+)
 
 func TestListenBaseURL_IPv4(t *testing.T) {
-	got := listenBaseURL("127.0.0.1", 8080)
+	got := listenBaseURL("127.0.0.1:8080")
 	want := "http://127.0.0.1:8080"
 	if got != want {
 		t.Fatalf("listenBaseURL: got %q, want %q", got, want)
 	}
 }
 
+// net.Listener.Addr().String() は IPv6 ホストを角括弧付きで返すため、
+// その形式をそのまま受け取れることを確認する。
 func TestListenBaseURL_IPv6(t *testing.T) {
-	got := listenBaseURL("::1", 3123)
+	got := listenBaseURL("[::1]:3123")
 	want := "http://[::1]:3123"
 	if got != want {
 		t.Fatalf("listenBaseURL: got %q, want %q", got, want)
@@ -19,9 +24,35 @@ func TestListenBaseURL_IPv6(t *testing.T) {
 }
 
 func TestListenBaseURL_AllInterfaces(t *testing.T) {
-	got := listenBaseURL("0.0.0.0", 3123)
+	got := listenBaseURL("0.0.0.0:3123")
 	want := "http://0.0.0.0:3123"
 	if got != want {
 		t.Fatalf("listenBaseURL: got %q, want %q", got, want)
+	}
+}
+
+// 最初の WriteHeader だけが記録され、後続の（net/http では無視される）
+// 余分な WriteHeader でログ用ステータスが上書きされないことを確認する。
+func TestLoggingResponseWriter_FirstWriteHeaderWins(t *testing.T) {
+	rec := httptest.NewRecorder()
+	lw := &loggingResponseWriter{ResponseWriter: rec, status: 200}
+	lw.WriteHeader(404)
+	lw.WriteHeader(500)
+	if lw.status != 404 {
+		t.Fatalf("status: got %d, want 404 (first WriteHeader)", lw.status)
+	}
+}
+
+// Write が先行した場合は暗黙の 200 が確定し、その後の WriteHeader は
+// 実際には送られないため記録も 200 のまま維持されることを確認する。
+func TestLoggingResponseWriter_WriteImplies200(t *testing.T) {
+	rec := httptest.NewRecorder()
+	lw := &loggingResponseWriter{ResponseWriter: rec, status: 200}
+	if _, err := lw.Write([]byte("body")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	lw.WriteHeader(500)
+	if lw.status != 200 {
+		t.Fatalf("status: got %d, want 200 (implicit by Write)", lw.status)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,15 +87,21 @@ func (s *Server) Run(ctx context.Context) error {
 	mux := s.newMux()
 	handler := s.withAccessLog(mux)
 	addr := net.JoinHostPort(s.cfg.Listen, strconv.Itoa(s.cfg.Port))
+	// リスナーを明示的に作り、--port=0（OS 割当）でも実際のバインド先を
+	// 起動ログへ出せるようにする（logStartup は実アドレスを受け取る）。
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
 	s.server = &http.Server{Addr: addr, Handler: handler}
-	s.logStartup(addr)
+	s.logStartup(ln.Addr().String())
 
 	signalCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	errCh := make(chan error, 1)
 	go func() {
-		if err := s.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := s.server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 			return
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,8 +85,10 @@ func New(cfg Config, spaFS fs.FS) (*Server, error) {
 // ListenAndServe 由来のエラーを優先する。
 func (s *Server) Run(ctx context.Context) error {
 	mux := s.newMux()
+	handler := s.withAccessLog(mux)
 	addr := net.JoinHostPort(s.cfg.Listen, strconv.Itoa(s.cfg.Port))
-	s.server = &http.Server{Addr: addr, Handler: mux}
+	s.server = &http.Server{Addr: addr, Handler: handler}
+	s.logStartup(addr)
 
 	signalCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()


### PR DESCRIPTION
## 概要

バージョン 2（`version-202605`）向けの独立した改善 4 件をまとめた PR です。コミット単位で関心事を分離しています。

### 1. fix(parser): JSON 出力の nil スライスを非 nil に正規化
`encoding/json` は nil スライスを `null` と書き出すため、空の `Groups` / `Comments` / `PrimaryKeys` / `IndexRefs` / `Index.Columns` を受け取った SPA 側で配列前提の `.join` が落ちる。`convertTable` / `convertColumn` で常に非 nil スライスを生成し、テストで固定。

### 2. fix(frontend): null 配列フィールドを空配列へ正規化
旧サーバが書き出した JSON や過去の localStorage 下書きに残る `null` 配列への防御。`normalizeSchema` を追加し `getSchema` / `loadDraft` の入口で適用。サーバ側修正（1.）とは独立に、古い下書きデータの後方互換のために両層で正規化する。

### 3. feat(serve): 起動サマリとアクセスログを stderr へ出力
起動時に listen アドレス・ベース URL・スキーマ/レイアウトパス・書込モード・graphviz dot の有無を表示。リクエストごとにメソッド・パス・ステータス・処理時間・クライアントをログ。

### 4. build(make): gox 探索を GOPATH/bin まで拡張
PATH に gox が無くても `go install` 直後の GOPATH/bin から探索して `make release` を実行可能に。`make build` に生成先の案内メッセージを追加。

## テスト

- `go test ./...` 全パッケージ ok
- frontend: vitest 53 件パス、`npm run build`（tsc + vite）成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7aGqzkJXcfLK9eBYHp73