### PR TITLE
feat(layout): ELK 自動配置を primary グループ階層対応にし Go とクロスチェック（#27, #30）

### DIFF
--- a/frontend/src/layout/cross-check.test.ts
+++ b/frontend/src/layout/cross-check.test.ts
@@ -1,0 +1,72 @@
+// クライアント側 `buildElkInput` と Go 側 `internal/elk` の ELK 入力グラフ
+// 「構造」の一致を検証するクロスチェックテスト（ADR-0001）。
+//
+// 共有 fixture（`testdata/elk-cross-check-fixtures.json`）から ELK 入力を構築し、
+// 「一致すべき構造」= primary グループ所属 + エッジ集合 を抽出して、Go 側が生成した
+// 期待値（`testdata/expected/<name>.elk-structure.json`）と比較する。
+// 期待値は Go 側 `internal/elk/cross_check_test.go` が真実の単一の源として生成する。
+// 期待値が古くなった場合は Go 側テストが先に失敗する。
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { ElkNode } from 'elkjs/lib/elk.bundled.js'
+import { describe, expect, it } from 'vitest'
+import type { Schema } from '../model'
+import { buildElkInput } from './elk'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const FIXTURES_PATH = path.join(__dirname, 'testdata', 'elk-cross-check-fixtures.json')
+const EXPECTED_DIR = path.join(__dirname, 'testdata', 'expected')
+
+interface StructureSummary {
+  groups: { id: string; tables: string[] }[]
+  ungrouped: string[]
+  edges: { source: string; target: string }[]
+}
+
+// summarize は ELK 入力ルートから「一致すべき構造」を抽出する。
+// Go 側 `summarizeRoot` と同じ規則: children を持つノード=groupNode、
+// それ以外=ungrouped テーブル。エッジは親→子（sources[0]→targets[0]）。
+function summarize(root: ElkNode): StructureSummary {
+  const groups: { id: string; tables: string[] }[] = []
+  const ungrouped: string[] = []
+  for (const child of root.children ?? []) {
+    if (child.children && child.children.length > 0) {
+      groups.push({ id: child.id, tables: child.children.map((m) => m.id) })
+    } else {
+      ungrouped.push(child.id)
+    }
+  }
+  const edges = (root.edges ?? []).map((e) => ({
+    source: e.sources[0]!,
+    target: e.targets[0]!,
+  }))
+  return { groups, ungrouped, edges }
+}
+
+function loadFixtures(): Record<string, Schema> {
+  return JSON.parse(fs.readFileSync(FIXTURES_PATH, 'utf8')) as Record<string, Schema>
+}
+
+function loadExpected(name: string): StructureSummary {
+  const raw = fs.readFileSync(path.join(EXPECTED_DIR, `${name}.elk-structure.json`), 'utf8')
+  return JSON.parse(raw) as StructureSummary
+}
+
+describe('ELK structure cross-check vs Go reference', () => {
+  const fixtures = loadFixtures()
+  const names = Object.keys(fixtures).sort()
+
+  it('covers every fixture with an expected golden', () => {
+    expect(names.length).toBeGreaterThan(0)
+  })
+
+  for (const name of names) {
+    it(`matches Go structure for ${name}`, () => {
+      const got = summarize(buildElkInput(fixtures[name]!))
+      expect(got).toEqual(loadExpected(name))
+    })
+  }
+})

--- a/frontend/src/layout/elk.test.ts
+++ b/frontend/src/layout/elk.test.ts
@@ -1,0 +1,89 @@
+// elk.ts の純粋関数（buildElkInput の階層構造 / extractPositions の座標平坦化）の
+// 単体テスト。elkjs 実行を伴うレイアウトそのものはブラウザ実行のためここでは扱わず、
+// グループ入れ子由来の絶対座標算出ロジックを重点的に検証する。
+
+import type { ElkNode } from 'elkjs/lib/elk.bundled.js'
+import { describe, expect, it } from 'vitest'
+import type { Schema } from '../model'
+import { buildElkInput, computeLayout, extractPositions, sanitizeId } from './elk'
+
+const schema: Schema = {
+  Title: 't',
+  Groups: ['auth'],
+  Tables: [
+    {
+      Name: 'users',
+      LogicalName: '',
+      Columns: [],
+      PrimaryKeys: [],
+      Indexes: [],
+      Groups: ['auth'],
+    },
+    {
+      Name: 'guests',
+      LogicalName: '',
+      Columns: [],
+      PrimaryKeys: [],
+      Indexes: [],
+      Groups: [],
+    },
+  ],
+}
+
+describe('sanitizeId', () => {
+  it('keeps ASCII identifiers unchanged', () => {
+    expect(sanitizeId('users_1')).toBe('users_1')
+  })
+  it('replaces non-identifier chars with underscore', () => {
+    expect(sanitizeId('Order Mgmt')).toBe('Order_Mgmt')
+    expect(sanitizeId('売上')).toBe('__')
+  })
+})
+
+describe('buildElkInput', () => {
+  it('nests primary-group members under a group node and keeps ungrouped at root', () => {
+    const root = buildElkInput(schema)
+    const groupNode = root.children?.find((c) => c.id === 'auth')
+    expect(groupNode?.children?.map((m) => m.id)).toEqual(['users'])
+    expect(root.children?.some((c) => c.id === 'guests' && !c.children)).toBe(true)
+  })
+})
+
+describe('extractPositions', () => {
+  it('converts group-relative child coordinates to absolute positions', () => {
+    // auth グループは (100,50) に配置され、その中の users は親からの相対 (10,20)。
+    // guests はルート直下 (300,0)。絶対座標は users=(110,70), guests=(300,0)。
+    const laidOut: ElkNode = {
+      id: 'root',
+      children: [
+        {
+          id: 'auth',
+          x: 100,
+          y: 50,
+          children: [{ id: 'users', x: 10, y: 20, width: 200, height: 100 }],
+        },
+        { id: 'guests', x: 300, y: 0, width: 200, height: 100 },
+      ],
+    }
+    expect(extractPositions(laidOut)).toEqual({
+      users: { x: 110, y: 70 },
+      guests: { x: 300, y: 0 },
+    })
+  })
+
+  it('throws when ELK omits coordinates (fail fast)', () => {
+    const bad: ElkNode = { id: 'root', children: [{ id: 'x', width: 200, height: 100 }] }
+    expect(() => extractPositions(bad)).toThrow(/did not return coordinates/)
+  })
+})
+
+describe('computeLayout (real elkjs)', () => {
+  it('returns absolute coordinates for grouped and ungrouped tables alike', async () => {
+    const layout = await computeLayout(schema)
+    // グループ内(users)・グループ外(guests)いずれも絶対座標が得られること。
+    expect(typeof layout.users?.x).toBe('number')
+    expect(typeof layout.users?.y).toBe('number')
+    expect(typeof layout.guests?.x).toBe('number')
+    expect(typeof layout.guests?.y).toBe('number')
+  })
+})

--- a/frontend/src/layout/elk.test.ts
+++ b/frontend/src/layout/elk.test.ts
@@ -47,6 +47,28 @@ describe('buildElkInput', () => {
     expect(groupNode?.children?.map((m) => m.id)).toEqual(['users'])
     expect(root.children?.some((c) => c.id === 'guests' && !c.children)).toBe(true)
   })
+
+  it('uses raw Table.Name as node id so it matches Layout / mergePositions keys', () => {
+    const root = buildElkInput(schema)
+    const groupNode = root.children?.find((c) => c.id === 'auth')
+    // Table.Name をそのまま id に使う（sanitize しない）。
+    expect(groupNode?.children?.[0]?.id).toBe('users')
+  })
+
+  it('recovers grouped tables even when Schema.Groups is out of sync (draft edit)', () => {
+    // Editor が Table.Groups だけ更新し Schema.Groups が空のままの下書き状態でも、
+    // grouped テーブルが ELK 入力から欠落しないこと（Copilot 指摘）。
+    const draft: Schema = {
+      Title: 't',
+      Groups: [],
+      Tables: [
+        { Name: 'users', LogicalName: '', Columns: [], PrimaryKeys: [], Indexes: [], Groups: ['auth'] },
+      ],
+    }
+    const root = buildElkInput(draft)
+    const groupNode = root.children?.find((c) => c.id === 'auth')
+    expect(groupNode?.children?.map((m) => m.id)).toEqual(['users'])
+  })
 })
 
 describe('extractPositions', () => {

--- a/frontend/src/layout/elk.ts
+++ b/frontend/src/layout/elk.ts
@@ -62,7 +62,7 @@ export function sanitizeId(name: string): string {
 export function buildElkInput(schema: Schema): ElkNode {
   const children: ElkNode[] = []
 
-  for (const name of schema.Groups) {
+  for (const name of effectiveGroupOrder(schema)) {
     const members = schema.Tables.filter((t) => primaryGroup(t) === name).map(
       buildTableNode,
     )
@@ -83,14 +83,44 @@ export function buildElkInput(schema: Schema): ElkNode {
   }
 }
 
+// effectiveGroupOrder は groupNode を並べる primary グループ名の順序を決める。
+//
+// 基本は Schema.Groups の登場順だが、編集中の下書きでは Editor が Table.Groups
+// だけ更新して Schema.Groups が追随していないことがあり得る。その場合でも
+// テーブルから発見した primary グループを（初出順で）末尾に補完し、grouped な
+// テーブルが ELK 入力から欠落して mergePositions が失敗するのを防ぐ。
+function effectiveGroupOrder(schema: Schema): string[] {
+  const seen = new Set<string>()
+  const order: string[] = []
+  const add = (name: string): void => {
+    if (!seen.has(name)) {
+      seen.add(name)
+      order.push(name)
+    }
+  }
+  for (const name of schema.Groups) add(name)
+  for (const t of schema.Tables) {
+    const pg = primaryGroup(t)
+    if (pg !== null) add(pg)
+  }
+  return order
+}
+
 // buildTableNode は Table 1 件を elkjs 互換のノードへ変換する。
+//
+// ノード id は Table.Name をそのまま使う（sanitize しない）。ELK 結果から
+// 復元する Layout のキーおよび Canvas / mergePositions が参照する Table.Name と
+// 一致させ、下書きで一時的に識別子規則外の名前になっても不整合が起きないように
+// する。グループ名だけは任意文字列を取り得るため sanitizeId で id 化する。
 function buildTableNode(t: Schema['Tables'][number]): ElkNode {
-  return { id: sanitizeId(t.Name), width: NODE_WIDTH, height: NODE_HEIGHT }
+  return { id: t.Name, width: NODE_WIDTH, height: NODE_HEIGHT }
 }
 
 // buildEdges は全テーブルを走査して親 → 子方向の FK エッジ列を生成する。
-// WithoutErd カラム由来のエッジは除外（要件 1.8）。ID にカラム名を含めることで
-// 同一親子間の複数 FK でも衝突しない（要件 4.3）。
+// WithoutErd カラム由来のエッジは除外（要件 1.8）。sources/targets は
+// テーブルノード id（= Table.Name）と一致させる。edge id はカラム名を含めて
+// 同一親子間の複数 FK でも衝突しないようにする（要件 4.3、sanitize は id 文字列の
+// 安全化のみに用いる）。
 function buildEdges(schema: Schema): ElkExtendedEdge[] {
   const edges: ElkExtendedEdge[] = []
   for (const t of schema.Tables) {
@@ -99,8 +129,8 @@ function buildEdges(schema: Schema): ElkExtendedEdge[] {
       if (c.FK === null) continue
       edges.push({
         id: `fk_${sanitizeId(t.Name)}_${sanitizeId(c.Name)}_${sanitizeId(c.FK.TargetTable)}`,
-        sources: [sanitizeId(c.FK.TargetTable)],
-        targets: [sanitizeId(t.Name)],
+        sources: [c.FK.TargetTable],
+        targets: [t.Name],
       })
     }
   }

--- a/frontend/src/layout/elk.ts
+++ b/frontend/src/layout/elk.ts
@@ -1,24 +1,25 @@
 // ELK 連携: スキーマから ELK 入力グラフを構築し、自動レイアウトを計算する
-// （タスク 7.4 / 要件 6.4 / 6.5、design.md §C11）。
+// （タスク 7.4 / 要件 6.4 / 6.5、design.md §C11、ADR-0001）。
 //
 // 設計判断:
 //   - `elkjs` のバンドル版（`elk.bundled.js`）を採用。Web Worker を使わず、
 //     呼び出し側の `useEffect` 内で `await` するだけで完結する。
 //   - 公開関数は `computeLayout(schema)` のみ。マージは `merge.ts` の責務。
-//   - ノード幅/高さは固定値（200x100）。カラム数連動は将来検討（design.md
-//     §C11、tasks.md 7.4 のスコープ外）。
+//     （`buildElkInput` / `extractPositions` はクロスチェック・単体テスト用に公開）
+//   - primary グループは ELK の階層（親ノードの children）として表現し、所属
+//     テーブルがまとまって配置されるようにする（ADR-0001、Go `internal/elk`
+//     の groupNode と構造を一致させる）。secondary グループはレイアウトに影響
+//     させない。
+//   - ノード幅/高さは固定値（200x100）。カラム数連動は将来検討（design.md §C11）。
 //   - エッジ方向は親（FK.TargetTable）→ 子（テーブル）。要件 1.6 と整合。
 //   - `WithoutErd === true` のカラムは ERD に現れないため、対応する FK は
 //     ELK 入力にも含めない（要件 1.8 と整合）。
 //   - ELK のレイアウトオプションは要件 1.1（rankdir=LR 相当）と DOT レンダラ
-//     既定値（`internal/dot`）に合わせる:
-//       * `elk.algorithm = layered`
-//       * `elk.direction = RIGHT`
-//       * `elk.spacing.nodeNode = 50`
-//       * `elk.layered.spacing.nodeNodeBetweenLayers = 80`
+//     既定値（`internal/dot`）に合わせる。階層エッジを跨いでレイアウトさせる
+//     ため `elk.hierarchyHandling = INCLUDE_CHILDREN` を指定する。
 
 import ELK, { type ElkNode, type ElkExtendedEdge } from 'elkjs/lib/elk.bundled.js'
-import type { Layout, Schema } from '../model'
+import { primaryGroup, type Layout, type Schema } from '../model'
 
 const NODE_WIDTH = 200
 const NODE_HEIGHT = 100
@@ -26,6 +27,7 @@ const NODE_HEIGHT = 100
 const ROOT_LAYOUT_OPTIONS: Record<string, string> = {
   'elk.algorithm': 'layered',
   'elk.direction': 'RIGHT',
+  'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
   'elk.spacing.nodeNode': '50',
   'elk.layered.spacing.nodeNodeBetweenLayers': '80',
 }
@@ -39,49 +41,94 @@ export async function computeLayout(schema: Schema): Promise<Layout> {
   return extractPositions(result)
 }
 
-// buildElkInput はスキーマから ELK 入力グラフ（root ノード）を構築する。
-function buildElkInput(schema: Schema): ElkNode {
-  const children: ElkNode[] = schema.Tables.map((t) => ({
-    id: t.Name,
-    width: NODE_WIDTH,
-    height: NODE_HEIGHT,
-  }))
+// sanitizeId は識別子を `[A-Za-z0-9_]` 範囲へ正規化する。Go 側 `internal/elk`
+// の `sanitizeID` と同一規則にして、クロスチェックでの構造一致を保つ。
+// グループ名は任意文字列（空白・日本語可）を取り得るため groupNode の id 化に
+// 使う。テーブル名は文法上すでに `[A-Za-z0-9_]+` のため実質恒等変換になる。
+export function sanitizeId(name: string): string {
+  let out = ''
+  for (const ch of name) {
+    out += /[A-Za-z0-9_]/.test(ch) ? ch : '_'
+  }
+  return out
+}
 
-  const edges: ElkExtendedEdge[] = []
+// buildElkInput はスキーマから ELK 入力グラフ（root ノード）を構築する。
+//
+// primary グループは Schema.Groups の登場順で groupNode（children を持つ親
+// ノード）として並べ、所属テーブルを Schema.Tables の登場順で格納する。primary
+// 所属テーブルが 0 件のグループは groupNode を出力しない（Go `internal/elk`
+// と同方針）。グループ未指定テーブルは root.children 直下に置く。
+export function buildElkInput(schema: Schema): ElkNode {
+  const children: ElkNode[] = []
+
+  for (const name of schema.Groups) {
+    const members = schema.Tables.filter((t) => primaryGroup(t) === name).map(
+      buildTableNode,
+    )
+    if (members.length === 0) continue
+    children.push({ id: sanitizeId(name), children: members })
+  }
+
   for (const t of schema.Tables) {
-    for (const c of t.Columns) {
-      if (c.WithoutErd) continue
-      if (c.FK === null) continue
-      edges.push({
-        id: `${c.FK.TargetTable}__${t.Name}__${c.Name}`,
-        sources: [c.FK.TargetTable],
-        targets: [t.Name],
-      })
-    }
+    if (primaryGroup(t) !== null) continue
+    children.push(buildTableNode(t))
   }
 
   return {
     id: 'root',
     layoutOptions: ROOT_LAYOUT_OPTIONS,
     children,
-    edges,
+    edges: buildEdges(schema),
   }
 }
 
-// extractPositions は ELK レイアウト結果から各テーブルの (x, y) を抽出する。
-// ELK は通常 root の children に各ノードの x/y を埋めて返す。
-function extractPositions(result: ElkNode): Layout {
-  const layout: Layout = {}
-  const children = result.children ?? []
-  for (const node of children) {
-    if (typeof node.x !== 'number' || typeof node.y !== 'number') {
-      // ELK が座標を返さなかった場合は Fail Fast。レイアウト計算の異常を
-      // サイレントに 0,0 で隠蔽しない。
-      throw new Error(
-        `ELK layout did not return coordinates for node "${node.id}"`,
-      )
+// buildTableNode は Table 1 件を elkjs 互換のノードへ変換する。
+function buildTableNode(t: Schema['Tables'][number]): ElkNode {
+  return { id: sanitizeId(t.Name), width: NODE_WIDTH, height: NODE_HEIGHT }
+}
+
+// buildEdges は全テーブルを走査して親 → 子方向の FK エッジ列を生成する。
+// WithoutErd カラム由来のエッジは除外（要件 1.8）。ID にカラム名を含めることで
+// 同一親子間の複数 FK でも衝突しない（要件 4.3）。
+function buildEdges(schema: Schema): ElkExtendedEdge[] {
+  const edges: ElkExtendedEdge[] = []
+  for (const t of schema.Tables) {
+    for (const c of t.Columns) {
+      if (c.WithoutErd) continue
+      if (c.FK === null) continue
+      edges.push({
+        id: `fk_${sanitizeId(t.Name)}_${sanitizeId(c.Name)}_${sanitizeId(c.FK.TargetTable)}`,
+        sources: [sanitizeId(c.FK.TargetTable)],
+        targets: [sanitizeId(t.Name)],
+      })
     }
-    layout[node.id] = { x: node.x, y: node.y }
   }
+  return edges
+}
+
+// extractPositions は ELK レイアウト結果から各テーブルの絶対 (x, y) を抽出する。
+//
+// groupNode（children を持つノード）配下のテーブル座標は親グループからの相対
+// 座標で返るため、親のオフセットを積算して絶対座標へ変換する。テーブルノード
+// （children を持たないノード）を Layout のエントリとして採用する。
+export function extractPositions(result: ElkNode): Layout {
+  const layout: Layout = {}
+
+  const walk = (nodes: readonly ElkNode[] | undefined, ox: number, oy: number): void => {
+    for (const node of nodes ?? []) {
+      if (typeof node.x !== 'number' || typeof node.y !== 'number') {
+        // ELK が座標を返さなかった場合は Fail Fast。0,0 でサイレントに隠蔽しない。
+        throw new Error(`ELK layout did not return coordinates for node "${node.id}"`)
+      }
+      if (node.children && node.children.length > 0) {
+        walk(node.children, ox + node.x, oy + node.y)
+      } else {
+        layout[node.id] = { x: ox + node.x, y: oy + node.y }
+      }
+    }
+  }
+
+  walk(result.children, 0, 0)
   return layout
 }

--- a/frontend/src/layout/testdata/elk-cross-check-fixtures.json
+++ b/frontend/src/layout/testdata/elk-cross-check-fixtures.json
@@ -1,0 +1,149 @@
+{
+  "01_simple_ungrouped": {
+    "Title": "simple_ungrouped",
+    "Groups": [],
+    "Tables": [
+      {
+        "Name": "users",
+        "Groups": [],
+        "Columns": [
+          { "Name": "id", "WithoutErd": false, "FK": null },
+          { "Name": "name", "WithoutErd": false, "FK": null }
+        ]
+      },
+      {
+        "Name": "posts",
+        "Groups": [],
+        "Columns": [
+          { "Name": "id", "WithoutErd": false, "FK": null },
+          {
+            "Name": "user_id",
+            "WithoutErd": false,
+            "FK": { "TargetTable": "users", "CardinalitySource": "0..*", "CardinalityDestination": "1" }
+          }
+        ]
+      }
+    ]
+  },
+  "02_primary_group_only": {
+    "Title": "primary_group_only",
+    "Groups": ["auth"],
+    "Tables": [
+      {
+        "Name": "users",
+        "Groups": ["auth"],
+        "Columns": [{ "Name": "id", "WithoutErd": false, "FK": null }]
+      },
+      {
+        "Name": "sessions",
+        "Groups": ["auth"],
+        "Columns": [
+          {
+            "Name": "user_id",
+            "WithoutErd": false,
+            "FK": { "TargetTable": "users", "CardinalitySource": "0..*", "CardinalityDestination": "1" }
+          }
+        ]
+      }
+    ]
+  },
+  "03_ungrouped_mixed": {
+    "Title": "ungrouped_mixed",
+    "Groups": ["auth"],
+    "Tables": [
+      {
+        "Name": "users",
+        "Groups": ["auth"],
+        "Columns": [{ "Name": "id", "WithoutErd": false, "FK": null }]
+      },
+      {
+        "Name": "guests",
+        "Groups": [],
+        "Columns": [{ "Name": "token", "WithoutErd": false, "FK": null }]
+      }
+    ]
+  },
+  "04_multi_fk_same_parent": {
+    "Title": "multi_fk_same_parent",
+    "Groups": [],
+    "Tables": [
+      {
+        "Name": "users",
+        "Groups": [],
+        "Columns": [{ "Name": "id", "WithoutErd": false, "FK": null }]
+      },
+      {
+        "Name": "audit_logs",
+        "Groups": [],
+        "Columns": [
+          {
+            "Name": "actor_id",
+            "WithoutErd": false,
+            "FK": { "TargetTable": "users", "CardinalitySource": "0..*", "CardinalityDestination": "1" }
+          },
+          {
+            "Name": "target_id",
+            "WithoutErd": false,
+            "FK": { "TargetTable": "users", "CardinalitySource": "0..*", "CardinalityDestination": "1" }
+          }
+        ]
+      }
+    ]
+  },
+  "05_without_erd_excluded": {
+    "Title": "without_erd_excluded",
+    "Groups": [],
+    "Tables": [
+      {
+        "Name": "users",
+        "Groups": [],
+        "Columns": [{ "Name": "id", "WithoutErd": false, "FK": null }]
+      },
+      {
+        "Name": "legacy",
+        "Groups": [],
+        "Columns": [
+          {
+            "Name": "user_id",
+            "WithoutErd": true,
+            "FK": { "TargetTable": "users", "CardinalitySource": "0..*", "CardinalityDestination": "1" }
+          },
+          { "Name": "note", "WithoutErd": false, "FK": null }
+        ]
+      }
+    ]
+  },
+  "06_group_name_with_space": {
+    "Title": "group_name_with_space",
+    "Groups": ["Order Mgmt"],
+    "Tables": [
+      {
+        "Name": "orders",
+        "Groups": ["Order Mgmt"],
+        "Columns": [{ "Name": "id", "WithoutErd": false, "FK": null }]
+      }
+    ]
+  },
+  "07_primary_and_secondary": {
+    "Title": "primary_and_secondary",
+    "Groups": ["core", "audit"],
+    "Tables": [
+      {
+        "Name": "users",
+        "Groups": ["core", "audit"],
+        "Columns": [{ "Name": "id", "WithoutErd": false, "FK": null }]
+      },
+      {
+        "Name": "events",
+        "Groups": ["core", "audit"],
+        "Columns": [
+          {
+            "Name": "user_id",
+            "WithoutErd": false,
+            "FK": { "TargetTable": "users", "CardinalitySource": "0..*", "CardinalityDestination": "1" }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/src/layout/testdata/expected/01_simple_ungrouped.elk-structure.json
+++ b/frontend/src/layout/testdata/expected/01_simple_ungrouped.elk-structure.json
@@ -1,0 +1,13 @@
+{
+  "groups": [],
+  "ungrouped": [
+    "users",
+    "posts"
+  ],
+  "edges": [
+    {
+      "source": "users",
+      "target": "posts"
+    }
+  ]
+}

--- a/frontend/src/layout/testdata/expected/02_primary_group_only.elk-structure.json
+++ b/frontend/src/layout/testdata/expected/02_primary_group_only.elk-structure.json
@@ -1,0 +1,18 @@
+{
+  "groups": [
+    {
+      "id": "auth",
+      "tables": [
+        "users",
+        "sessions"
+      ]
+    }
+  ],
+  "ungrouped": [],
+  "edges": [
+    {
+      "source": "users",
+      "target": "sessions"
+    }
+  ]
+}

--- a/frontend/src/layout/testdata/expected/03_ungrouped_mixed.elk-structure.json
+++ b/frontend/src/layout/testdata/expected/03_ungrouped_mixed.elk-structure.json
@@ -1,0 +1,14 @@
+{
+  "groups": [
+    {
+      "id": "auth",
+      "tables": [
+        "users"
+      ]
+    }
+  ],
+  "ungrouped": [
+    "guests"
+  ],
+  "edges": []
+}

--- a/frontend/src/layout/testdata/expected/04_multi_fk_same_parent.elk-structure.json
+++ b/frontend/src/layout/testdata/expected/04_multi_fk_same_parent.elk-structure.json
@@ -1,0 +1,17 @@
+{
+  "groups": [],
+  "ungrouped": [
+    "users",
+    "audit_logs"
+  ],
+  "edges": [
+    {
+      "source": "users",
+      "target": "audit_logs"
+    },
+    {
+      "source": "users",
+      "target": "audit_logs"
+    }
+  ]
+}

--- a/frontend/src/layout/testdata/expected/05_without_erd_excluded.elk-structure.json
+++ b/frontend/src/layout/testdata/expected/05_without_erd_excluded.elk-structure.json
@@ -1,0 +1,8 @@
+{
+  "groups": [],
+  "ungrouped": [
+    "users",
+    "legacy"
+  ],
+  "edges": []
+}

--- a/frontend/src/layout/testdata/expected/06_group_name_with_space.elk-structure.json
+++ b/frontend/src/layout/testdata/expected/06_group_name_with_space.elk-structure.json
@@ -1,0 +1,12 @@
+{
+  "groups": [
+    {
+      "id": "Order_Mgmt",
+      "tables": [
+        "orders"
+      ]
+    }
+  ],
+  "ungrouped": [],
+  "edges": []
+}

--- a/frontend/src/layout/testdata/expected/07_primary_and_secondary.elk-structure.json
+++ b/frontend/src/layout/testdata/expected/07_primary_and_secondary.elk-structure.json
@@ -1,0 +1,18 @@
+{
+  "groups": [
+    {
+      "id": "core",
+      "tables": [
+        "users",
+        "events"
+      ]
+    }
+  ],
+  "ungrouped": [],
+  "edges": [
+    {
+      "source": "users",
+      "target": "events"
+    }
+  ]
+}

--- a/frontend/src/model/groups.ts
+++ b/frontend/src/model/groups.ts
@@ -1,0 +1,19 @@
+// グループ判定のドメインヘルパ。Go 側 `internal/model` の
+// `Table.PrimaryGroup()` / `Table.SecondaryGroups()` と同義に保つ。
+//
+// セマンティクス（design.md §C6 / 要件 2.x）:
+//   - Table.Groups の先頭要素が primary グループ。
+//   - 2 要素目以降が secondary グループ。
+//   - primary グループのみが cluster / groupNode 描画の単位になる。
+
+import type { Table } from './types'
+
+// primaryGroup は Table の primary グループ名を返す。未所属なら null。
+export function primaryGroup(t: Table): string | null {
+  return t.Groups.length > 0 ? t.Groups[0]! : null
+}
+
+// secondaryGroups は secondary グループ名（Groups の 2 要素目以降）を返す。
+export function secondaryGroups(t: Table): string[] {
+  return t.Groups.length > 1 ? t.Groups.slice(1) : []
+}

--- a/frontend/src/model/index.ts
+++ b/frontend/src/model/index.ts
@@ -1,5 +1,6 @@
 // 公開境界: サーバ JSON ⇄ 内部 TS モデルの型定義をまとめて再エクスポートする
 // （design.md §C11）。実体は `./types` に集約しており、本ファイルは
 // `import { Schema } from '../model'` 形式の参照点として機能する。
+export * from './groups'
 export * from './normalize'
 export * from './types'

--- a/internal/elk/cross_check_test.go
+++ b/internal/elk/cross_check_test.go
@@ -1,0 +1,106 @@
+// cross_check_test.go は Go `internal/elk` とフロント `frontend/src/layout/elk.ts`
+// の ELK 入力グラフ「構造」の一致を担保するクロスチェックテスト（ADR-0001）。
+//
+// レイアウト計算そのものはブラウザ側（elkjs）が担うため一致対象にはしない。
+// ここで縛るのは「一致すべき構造」= (1) primary グループ所属（groupNode 階層）と
+// (2) エッジ集合（親→子、sanitizeID 正規化済み）である。
+//
+// 共有 fixture（`frontend/src/layout/testdata/elk-cross-check-fixtures.json`）を
+// Go の `*model.Schema` にデコードし、buildRoot から構造サマリを抽出して期待値
+// （`frontend/src/layout/testdata/expected/<name>.elk-structure.json`）と比較する。
+// 期待値は Go 側を「真実の単一の源」とし、UPDATE_GOLDEN=1 で再生成できる。
+// TS 側の cross-check.test.ts は同じ期待値ファイルへの一致を検証する。
+package elk
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/unok/erdm/internal/model"
+	"github.com/unok/erdm/internal/testutil/golden"
+)
+
+const (
+	elkFixturePath = "../../frontend/src/layout/testdata/elk-cross-check-fixtures.json"
+	elkExpectedDir = "../../frontend/src/layout/testdata/expected"
+)
+
+// elkStructureGroup は 1 つの primary グループとその所属テーブル ID 列。
+type elkStructureGroup struct {
+	ID     string   `json:"id"`
+	Tables []string `json:"tables"`
+}
+
+// elkStructureEdge は 1 本の FK エッジ（親→子）。
+type elkStructureEdge struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+}
+
+// elkStructureSummary は ELK 入力グラフの「一致すべき構造」だけを取り出したもの。
+// 座標・サイズ・layoutOptions は Go/TS で正当に異なるため含めない。
+type elkStructureSummary struct {
+	Groups    []elkStructureGroup `json:"groups"`
+	Ungrouped []string            `json:"ungrouped"`
+	Edges     []elkStructureEdge  `json:"edges"`
+}
+
+// summarizeRoot は elkRoot から構造サマリを抽出する。TS 側の同名処理と一致させる。
+func summarizeRoot(root *elkRoot) elkStructureSummary {
+	summary := elkStructureSummary{
+		Groups:    []elkStructureGroup{},
+		Ungrouped: []string{},
+		Edges:     []elkStructureEdge{},
+	}
+	for _, child := range root.Children {
+		if len(child.Children) > 0 {
+			tables := make([]string, 0, len(child.Children))
+			for _, member := range child.Children {
+				tables = append(tables, member.ID)
+			}
+			summary.Groups = append(summary.Groups, elkStructureGroup{ID: child.ID, Tables: tables})
+			continue
+		}
+		summary.Ungrouped = append(summary.Ungrouped, child.ID)
+	}
+	for _, e := range root.Edges {
+		summary.Edges = append(summary.Edges, elkStructureEdge{Source: e.Sources[0], Target: e.Targets[0]})
+	}
+	return summary
+}
+
+func TestElkStructure_CrossCheckWithFrontend(t *testing.T) {
+	raw, err := os.ReadFile(elkFixturePath)
+	if err != nil {
+		t.Fatalf("read fixtures: %v", err)
+	}
+	var fixtures map[string]*model.Schema
+	if err := json.Unmarshal(raw, &fixtures); err != nil {
+		t.Fatalf("unmarshal fixtures: %v", err)
+	}
+
+	names := make([]string, 0, len(fixtures))
+	for name := range fixtures {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			schema := fixtures[name]
+			if schema == nil {
+				t.Fatalf("fixture %s missing", name)
+			}
+			summary := summarizeRoot(buildRoot(schema))
+			got, err := json.MarshalIndent(summary, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal summary: %v", err)
+			}
+			got = append(got, '\n')
+			golden.Compare(t, got, filepath.Join(elkExpectedDir, name+".elk-structure.json"))
+		})
+	}
+}


### PR DESCRIPTION
ADR-0001 の方針（ELK は 2 実装維持 + 構造クロスチェック）に沿って、#27 の第一段階として **グループ対応の自動レイアウト + クロスチェック基盤**を実装します。グループ枠の描画（Canvas）と secondary バッジ/フィルタは後続 PR。

## 変更

### グループ階層レイアウト（#27 の一部）
- フロント `elk.ts` の ELK 入力を primary グループの階層（groupNode）付きに変更し、同一グループのテーブルがまとまって配置されるように
- 入れ子配下のテーブル座標は親グループのオフセットを積算して**絶対座標へ平坦化**（`Layout` は従来どおりテーブル名キーの絶対座標なので merge/Canvas は無変更）
- `model` に `primaryGroup` / `secondaryGroups` ヘルパを追加（Go の `Table` 同名メソッドと同義）

### 構造クロスチェック（#30 / ADR-0001）
- Go `internal/elk` とフロント `elk.ts` の「一致すべき構造」（primary グループ所属・親→子エッジ集合、`sanitizeID` 正規化済み）を、共有 fixture + 構造サマリ golden で照合
- シリアライザの前例踏襲: Go 側を真実の単一の源とし `UPDATE_GOLDEN=1` で再生成、TS 側は同じ golden への一致を検証
- 座標・サイズ・layoutOptions は正当に異なるため「構造サブセット一致」で縛る

## テスト
- 構造クロスチェック 8 件（Go golden ↔ TS `buildElkInput`）
- 座標平坦化・sanitize の単体、**実 elkjs を通した統合 1 件**（入れ子→絶対座標の経路確認）
- `go test ./...` 全パッケージ ok / frontend vitest 69 件 / `npm run build` 成功

## 後続（#27 の残作業）
- Canvas に primary グループ枠（背景ノード）を描画
- secondary グループのバッジ/色帯 + サイドバーのグループフィルタ

Refs #27, #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7aGqzkJXcfLK9eBYHp73