### PR TITLE
feat(canvas): primary グループを背景ボックスとして可視化する（#27）

### DIFF
--- a/frontend/src/components/Canvas/Canvas.test.tsx
+++ b/frontend/src/components/Canvas/Canvas.test.tsx
@@ -188,6 +188,28 @@ describe('Canvas', () => {
     expect(onNodeClick).toHaveBeenCalledWith('users')
   })
 
+  it('renders primary-group boxes behind table nodes and ignores clicks on them', () => {
+    const onNodeClick = vi.fn()
+    const GROUPED: Schema = {
+      Title: 't',
+      Groups: ['auth'],
+      Tables: [
+        { Name: 'users', LogicalName: '', Columns: [], PrimaryKeys: [], Indexes: [], Groups: ['auth'] },
+      ],
+    }
+    render(
+      <Canvas schema={GROUPED} initialLayout={{ users: { x: 0, y: 0 } }} onNodeClick={onNodeClick} />,
+    )
+    const nodes = JSON.parse(screen.getByTestId('rf-nodes').textContent ?? '[]') as Array<{
+      id: string
+    }>
+    // グループ枠がテーブルより前（背面）に並ぶ。
+    expect(nodes.map((n) => n.id)).toEqual(['group:auth', 'users'])
+    // 先頭（グループ枠）をクリックしても onNodeClick は呼ばれない。
+    screen.getByTestId('rf-click').click()
+    expect(onNodeClick).not.toHaveBeenCalled()
+  })
+
   it('updates nodes/edges when schema or layout props change (Copilot review #5)', () => {
     const SCHEMA_NEXT: Schema = {
       Title: 't',

--- a/frontend/src/components/Canvas/Canvas.tsx
+++ b/frontend/src/components/Canvas/Canvas.tsx
@@ -16,7 +16,7 @@
 //   - putLayout 失敗時はコンソール出力のみ（UI の閲覧/操作は継続）。閲覧モード
 //     の主目的（描画）が損なわれない方針。
 
-import { useCallback, useEffect, useRef, type JSX } from 'react'
+import { useCallback, useEffect, useMemo, useRef, type JSX } from 'react'
 import ReactFlow, {
   Background,
   Controls,
@@ -27,12 +27,19 @@ import ReactFlow, {
   type Node,
   type NodeDragHandler,
   type NodeMouseHandler,
+  type NodeTypes,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import { putLayout } from '../../api'
 import type { Layout, Schema } from '../../model'
+import { GroupBoxNode } from './GroupBoxNode'
+import { GROUP_BOX_NODE_TYPE, computeGroupBoxes, isGroupBoxId } from './groupBoxes'
 
 const SAVE_DEBOUNCE_MS = 500
+
+// nodeTypes は再インスタンス化を避けるためモジュールスコープの安定参照にする
+// （React Flow は毎レンダー新しい nodeTypes を渡すと警告する）。
+const NODE_TYPES: NodeTypes = { [GROUP_BOX_NODE_TYPE]: GroupBoxNode }
 
 export interface CanvasProps {
   schema: Schema
@@ -49,6 +56,12 @@ export function Canvas({ schema, initialLayout, onNodeClick }: CanvasProps): JSX
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
   const debounceTimerRef = useRef<number | null>(null)
+
+  // primary グループの背景枠を現在のテーブル配置から導出し、テーブルノードの
+  // 背面に重ねて描画する。テーブルが動くと nodes が変わり枠も再計算＝追従する。
+  const displayNodes = useMemo(() => {
+    return [...computeGroupBoxes(schema, nodes), ...nodes]
+  }, [schema, nodes])
 
   // schema / initialLayout が更新されたら React Flow の state を同期する。
   // useNodesState は初期値しか拾わないため、Editor 側でテーブル追加/編集して
@@ -67,6 +80,8 @@ export function Canvas({ schema, initialLayout, onNodeClick }: CanvasProps): JSX
       debounceTimerRef.current = null
       const layout: Layout = {}
       for (const n of latestNodes) {
+        // グループ枠は導出ノードなので座標を永続化しない（テーブルのみ保存）。
+        if (isGroupBoxId(n.id)) continue
         layout[n.id] = { x: n.position.x, y: n.position.y }
       }
       void putLayout(layout).catch((err: unknown) => {
@@ -86,6 +101,8 @@ export function Canvas({ schema, initialLayout, onNodeClick }: CanvasProps): JSX
 
   const onNodeClickHandler: NodeMouseHandler = useCallback(
     (_event, node) => {
+      // グループ枠クリックはテーブル選択ではないので無視する。
+      if (isGroupBoxId(node.id)) return
       onNodeClick?.(node.id)
     },
     [onNodeClick],
@@ -102,8 +119,9 @@ export function Canvas({ schema, initialLayout, onNodeClick }: CanvasProps): JSX
 
   return (
     <ReactFlow
-      nodes={nodes}
+      nodes={displayNodes}
       edges={edges}
+      nodeTypes={NODE_TYPES}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       onNodeDragStop={onNodeDragStop}

--- a/frontend/src/components/Canvas/GroupBoxNode.tsx
+++ b/frontend/src/components/Canvas/GroupBoxNode.tsx
@@ -11,6 +11,9 @@ export function GroupBoxNode({ data }: NodeProps<{ label: string }>): JSX.Elemen
   return (
     <div
       style={{
+        // ラベルの絶対配置がこの枠を基準になるよう positioned ancestor にする
+        // （React Flow のラッパ DOM 構造に依存しない自己完結）。
+        position: 'relative',
         width: '100%',
         height: '100%',
         boxSizing: 'border-box',

--- a/frontend/src/components/Canvas/GroupBoxNode.tsx
+++ b/frontend/src/components/Canvas/GroupBoxNode.tsx
@@ -1,0 +1,38 @@
+// primary グループの背景枠を描く React Flow カスタムノード（#27）。
+//
+// 接続ハンドル（Handle）を持たない純粋な装飾ノード。左上にグループ名を表示し、
+// 破線の枠と淡い背景でテーブル群の所属を示す。クリック・ドラッグはノード側の
+// draggable/selectable=false（computeGroupBoxes が設定）で無効化される。
+
+import type { JSX } from 'react'
+import type { NodeProps } from 'reactflow'
+
+export function GroupBoxNode({ data }: NodeProps<{ label: string }>): JSX.Element {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        boxSizing: 'border-box',
+        border: '1px dashed #7a7a7a',
+        borderRadius: 6,
+        background: 'rgba(120, 120, 120, 0.06)',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 4,
+          left: 8,
+          fontSize: 12,
+          fontWeight: 600,
+          color: '#555',
+          pointerEvents: 'none',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {data.label}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Canvas/groupBoxes.test.ts
+++ b/frontend/src/components/Canvas/groupBoxes.test.ts
@@ -1,0 +1,65 @@
+import type { Node } from 'reactflow'
+import { describe, expect, it } from 'vitest'
+import type { Schema } from '../../model'
+import { GROUP_BOX_PREFIX, computeGroupBoxes, isGroupBoxId } from './groupBoxes'
+
+function table(name: string, groups: string[]): Schema['Tables'][number] {
+  return { Name: name, LogicalName: '', Columns: [], PrimaryKeys: [], Indexes: [], Groups: groups }
+}
+
+const schema: Schema = {
+  Title: 't',
+  Groups: ['auth'],
+  Tables: [table('users', ['auth']), table('sessions', ['auth']), table('guests', [])],
+}
+
+const tableNodes: Node[] = [
+  { id: 'users', position: { x: 0, y: 0 }, width: 150, height: 40, data: {} },
+  { id: 'sessions', position: { x: 200, y: 100 }, width: 150, height: 40, data: {} },
+  { id: 'guests', position: { x: 500, y: 0 }, width: 150, height: 40, data: {} },
+]
+
+describe('isGroupBoxId', () => {
+  it('matches the group box prefix only', () => {
+    expect(isGroupBoxId(`${GROUP_BOX_PREFIX}auth`)).toBe(true)
+    expect(isGroupBoxId('users')).toBe(false)
+  })
+})
+
+describe('computeGroupBoxes', () => {
+  it('emits one non-interactive box wrapping the primary-group members', () => {
+    const boxes = computeGroupBoxes(schema, tableNodes)
+    expect(boxes.map((b) => b.id)).toEqual(['group:auth'])
+    const box = boxes[0]!
+    // auth メンバー bbox = (0,0)-(350,140)。余白 24、ラベル高 22。
+    expect(box.position).toEqual({ x: -24, y: -46 })
+    expect(box.style?.width).toBe(398)
+    expect(box.style?.height).toBe(210)
+    expect(box.data).toEqual({ label: 'auth' })
+    expect(box.draggable).toBe(false)
+    expect(box.selectable).toBe(false)
+  })
+
+  it('omits groups whose members are not present in the current nodes', () => {
+    // auth メンバーのノードが 1 つも無ければ枠を出さない。
+    expect(computeGroupBoxes(schema, [tableNodes[2]!])).toEqual([])
+  })
+
+  it('returns no boxes for an ungrouped schema', () => {
+    const ungrouped: Schema = { Title: 't', Groups: [], Tables: [table('a', []), table('b', [])] }
+    const nodes: Node[] = [
+      { id: 'a', position: { x: 0, y: 0 }, data: {} },
+      { id: 'b', position: { x: 10, y: 0 }, data: {} },
+    ]
+    expect(computeGroupBoxes(ungrouped, nodes)).toEqual([])
+  })
+
+  it('falls back to default node size when width/height are unmeasured', () => {
+    const nodes: Node[] = [{ id: 'users', position: { x: 0, y: 0 }, data: {} }]
+    const single: Schema = { Title: 't', Groups: ['auth'], Tables: [table('users', ['auth'])] }
+    const box = computeGroupBoxes(single, nodes)[0]!
+    // 既定 150x40 + 余白。width = 150 + 48 = 198, height = 40 + 48 + 22 = 110。
+    expect(box.style?.width).toBe(198)
+    expect(box.style?.height).toBe(110)
+  })
+})

--- a/frontend/src/components/Canvas/groupBoxes.ts
+++ b/frontend/src/components/Canvas/groupBoxes.ts
@@ -35,22 +35,27 @@ const LABEL_HEIGHT = 22
 export function computeGroupBoxes(schema: Schema, tableNodes: Node[]): Node[] {
   const byName = new Map(tableNodes.map((n) => [n.id, n]))
 
-  // primary グループを初出順で列挙（Schema.Groups 非同期な下書きにも頑健）。
+  // テーブルを 1 パスで走査し、primary グループの初出順（Schema.Groups 非同期な
+  // 下書きにも頑健）とメンバー Node を同時に収集する（グループ×テーブルの
+  // 二重走査を避ける）。
   const order: string[] = []
-  const seen = new Set<string>()
+  const membersByGroup = new Map<string, Node[]>()
   for (const t of schema.Tables) {
     const pg = primaryGroup(t)
-    if (pg !== null && !seen.has(pg)) {
-      seen.add(pg)
+    if (pg === null) continue
+    let members = membersByGroup.get(pg)
+    if (members === undefined) {
+      members = []
+      membersByGroup.set(pg, members)
       order.push(pg)
     }
+    const node = byName.get(t.Name)
+    if (node !== undefined) members.push(node)
   }
 
   const boxes: Node[] = []
   for (const name of order) {
-    const members = schema.Tables.filter((t) => primaryGroup(t) === name)
-      .map((t) => byName.get(t.Name))
-      .filter((n): n is Node => n !== undefined)
+    const members = membersByGroup.get(name) ?? []
     if (members.length === 0) continue
 
     let minX = Infinity

--- a/frontend/src/components/Canvas/groupBoxes.ts
+++ b/frontend/src/components/Canvas/groupBoxes.ts
@@ -1,0 +1,87 @@
+// primary グループの可視化用「背景ボックス」ノードを計算する純粋関数
+// （#27、ADR-0001）。
+//
+// 方針:
+//   - テーブルノードは従来どおりトップレベルの絶対座標のまま（永続化=絶対座標を
+//     維持）。グループ枠はメンバーテーブルの外接矩形（bbox）に余白を足した
+//     非インタラクティブな背景ノードとして描画する。
+//   - primary グループのみを枠にする（secondary は対象外、DOT cluster と同方針）。
+//   - メンバーが 0 件のグループは枠を出さない。
+//   - ノードの実寸はレンダリング後に React Flow が測って width/height に入れる。
+//     未測定時は既定値で近似する（初回描画のちらつきは許容範囲）。
+
+import type { Node } from 'reactflow'
+import { primaryGroup, type Schema } from '../../model'
+
+// グループ枠ノードの id 接頭辞。テーブルノード（= Table.Name）と区別し、
+// 座標保存・クリック選択の対象外にするために用いる。
+export const GROUP_BOX_PREFIX = 'group:'
+
+export function isGroupBoxId(id: string): boolean {
+  return id.startsWith(GROUP_BOX_PREFIX)
+}
+
+// React Flow のカスタムノード種別名（Canvas の nodeTypes に登録）。
+export const GROUP_BOX_NODE_TYPE = 'groupBox'
+
+// 実寸未測定時の近似値と余白。
+const DEFAULT_NODE_WIDTH = 150
+const DEFAULT_NODE_HEIGHT = 40
+const PADDING = 24
+const LABEL_HEIGHT = 22
+
+// computeGroupBoxes は現在のテーブルノード配置から primary グループの背景枠
+// ノード列を計算する。テーブルが動けば（再計算されれば）枠も追従する。
+export function computeGroupBoxes(schema: Schema, tableNodes: Node[]): Node[] {
+  const byName = new Map(tableNodes.map((n) => [n.id, n]))
+
+  // primary グループを初出順で列挙（Schema.Groups 非同期な下書きにも頑健）。
+  const order: string[] = []
+  const seen = new Set<string>()
+  for (const t of schema.Tables) {
+    const pg = primaryGroup(t)
+    if (pg !== null && !seen.has(pg)) {
+      seen.add(pg)
+      order.push(pg)
+    }
+  }
+
+  const boxes: Node[] = []
+  for (const name of order) {
+    const members = schema.Tables.filter((t) => primaryGroup(t) === name)
+      .map((t) => byName.get(t.Name))
+      .filter((n): n is Node => n !== undefined)
+    if (members.length === 0) continue
+
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+    for (const m of members) {
+      const w = m.width ?? DEFAULT_NODE_WIDTH
+      const h = m.height ?? DEFAULT_NODE_HEIGHT
+      minX = Math.min(minX, m.position.x)
+      minY = Math.min(minY, m.position.y)
+      maxX = Math.max(maxX, m.position.x + w)
+      maxY = Math.max(maxY, m.position.y + h)
+    }
+
+    boxes.push({
+      id: GROUP_BOX_PREFIX + name,
+      type: GROUP_BOX_NODE_TYPE,
+      position: { x: minX - PADDING, y: minY - PADDING - LABEL_HEIGHT },
+      data: { label: name },
+      style: {
+        width: maxX - minX + PADDING * 2,
+        height: maxY - minY + PADDING * 2 + LABEL_HEIGHT,
+      },
+      draggable: false,
+      selectable: false,
+      connectable: false,
+      deletable: false,
+      // テーブルノードより背面へ。
+      zIndex: -1,
+    })
+  }
+  return boxes
+}


### PR DESCRIPTION
#27 の第二段階として、キャンバス上に primary グループを **DOT cluster 相当の背景ボックス**で可視化します（ADR-0001 の派生背景ボックス方式）。

## 実装

- **`computeGroupBoxes`**（純粋関数）: primary グループのメンバー外接矩形＋余白から背景枠ノードを導出。メンバー 0 件のグループは枠を出さない。ノード実寸未測定時は既定値で近似
- **`GroupBoxNode`**: 破線枠＋左上ラベルの装飾専用ノード（接続ハンドルなし）
- **`Canvas`**: 枠をテーブルより前（背面）に重ねる。テーブルは従来どおり**トップレベルの絶対座標**のまま＝**永続化は無変更**。座標保存・クリック選択の対象から枠を除外。テーブルが動けば `useMemo` で枠を再計算＝追従

永続化（`putLayout` の絶対座標）に手を入れないため、既存の merge/保存ロジックは変更なし。

## テスト・検証

- `computeGroupBoxes` 単体 5 件（bbox 幾何・メンバー不在・ungrouped・既定サイズ）、Canvas 統合（枠が背面に並ぶ・枠クリック無視）
- frontend vitest 77 件 / `npm run build` / `go test ./...` 全 green
- **実アプリ（`erdm serve`）で視覚確認**: auth / shop グループ枠が描画され、guests（ungrouped）は枠外、FK エッジが枠をまたいで正しくルーティング（スクリーンショット確認済み）

## 後続（#27 の残作業）
- secondary グループのバッジ/色帯 + サイドバーのグループフィルタ

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7aGqzkJXcfLK9eBYHp73