### PR TITLE
feat(canvas): テーブルノードにカラム・型・PK/制約/FK を表示する（#28）

### DIFF
--- a/frontend/src/components/Canvas/Canvas.test.tsx
+++ b/frontend/src/components/Canvas/Canvas.test.tsx
@@ -165,11 +165,11 @@ describe('Canvas', () => {
     render(<Canvas schema={SCHEMA} initialLayout={LAYOUT} />)
     const nodes = JSON.parse(screen.getByTestId('rf-nodes').textContent ?? '[]') as Array<{
       id: string
-      data: { label: string }
+      data: { table: { Name: string } }
     }>
     expect(nodes.map((n) => n.id)).toEqual(['users', 'orders'])
-    // ラベルは LogicalName / Name の両方を含む（"会員 / users"）。
-    expect(nodes[0]?.data.label).toContain('users')
+    // カスタムテーブルノードには Table 実体が data.table として載る。
+    expect(nodes[0]?.data.table.Name).toBe('users')
 
     const edges = JSON.parse(screen.getByTestId('rf-edges').textContent ?? '[]') as Array<{
       id: string

--- a/frontend/src/components/Canvas/Canvas.tsx
+++ b/frontend/src/components/Canvas/Canvas.tsx
@@ -34,12 +34,19 @@ import { putLayout } from '../../api'
 import type { Layout, Schema } from '../../model'
 import { GroupBoxNode } from './GroupBoxNode'
 import { GROUP_BOX_NODE_TYPE, computeGroupBoxes, isGroupBoxId } from './groupBoxes'
+import { TableNode } from './TableNode'
 
 const SAVE_DEBOUNCE_MS = 500
 
+// テーブルノードのカスタム種別名。
+const TABLE_NODE_TYPE = 'tableNode'
+
 // nodeTypes は再インスタンス化を避けるためモジュールスコープの安定参照にする
 // （React Flow は毎レンダー新しい nodeTypes を渡すと警告する）。
-const NODE_TYPES: NodeTypes = { [GROUP_BOX_NODE_TYPE]: GroupBoxNode }
+const NODE_TYPES: NodeTypes = {
+  [TABLE_NODE_TYPE]: TableNode,
+  [GROUP_BOX_NODE_TYPE]: GroupBoxNode,
+}
 
 export interface CanvasProps {
   schema: Schema
@@ -143,12 +150,11 @@ function buildNodes(schema: Schema, layout: Layout): Node[] {
       // Fail Fast でバグを早期に表面化させる。
       throw new Error(`Missing position for table "${t.Name}" in canvas input`)
     }
-    const label = t.LogicalName !== '' ? `${t.LogicalName} / ${t.Name}` : t.Name
     return {
       id: t.Name,
-      type: 'default',
+      type: TABLE_NODE_TYPE,
       position: { x: pos.x, y: pos.y },
-      data: { label },
+      data: { table: t },
     }
   })
 }

--- a/frontend/src/components/Canvas/TableNode.test.ts
+++ b/frontend/src/components/Canvas/TableNode.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { Column } from '../../model'
+import { columnBadges } from './TableNode'
+
+function col(over: Partial<Column>): Column {
+  return {
+    Name: 'c',
+    LogicalName: '',
+    Type: 'int',
+    AllowNull: true,
+    IsUnique: false,
+    IsPrimaryKey: false,
+    Default: '',
+    Comments: [],
+    WithoutErd: false,
+    FK: null,
+    IndexRefs: [],
+    ...over,
+  }
+}
+
+describe('columnBadges', () => {
+  it('marks NOT NULL columns with NN', () => {
+    expect(columnBadges(col({ AllowNull: false }))).toEqual(['NN'])
+  })
+
+  it('marks unique columns with U', () => {
+    expect(columnBadges(col({ IsUnique: true }))).toEqual(['U'])
+  })
+
+  it('collapses NOT NULL + unique into UNN', () => {
+    expect(columnBadges(col({ AllowNull: false, IsUnique: true }))).toEqual(['UNN'])
+  })
+
+  it('appends FK when the column has a foreign key', () => {
+    const fk = col({ AllowNull: false, FK: { TargetTable: 'users', CardinalitySource: '0..*', CardinalityDestination: '1' } })
+    expect(columnBadges(fk)).toEqual(['NN', 'FK'])
+  })
+
+  it('returns no badges for a plain nullable column', () => {
+    expect(columnBadges(col({}))).toEqual([])
+  })
+
+  it('does not include PK (shown as an icon, not a badge)', () => {
+    expect(columnBadges(col({ IsPrimaryKey: true }))).toEqual([])
+  })
+})

--- a/frontend/src/components/Canvas/TableNode.tsx
+++ b/frontend/src/components/Canvas/TableNode.tsx
@@ -85,9 +85,13 @@ export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
                 whiteSpace: 'nowrap',
               }}
             >
-              <span style={{ width: 12, textAlign: 'center' }} aria-label={c.IsPrimaryKey ? 'primary key' : undefined}>
-                {c.IsPrimaryKey ? '🔑' : ''}
-              </span>
+              {c.IsPrimaryKey ? (
+                <span role="img" aria-label="primary key" style={{ width: 12, textAlign: 'center' }}>
+                  🔑
+                </span>
+              ) : (
+                <span aria-hidden="true" style={{ width: 12 }} />
+              )}
               <span style={{ flex: 1 }}>{columnLabel(c)}</span>
               <span style={{ color: '#888' }}>{c.Type}</span>
               {badges.map((b) => (

--- a/frontend/src/components/Canvas/TableNode.tsx
+++ b/frontend/src/components/Canvas/TableNode.tsx
@@ -1,0 +1,115 @@
+// テーブルを「ヘッダ＋カラム行」で描く React Flow カスタムノード（#28）。
+//
+// 表示規約は DOT レンダラ（internal/dot）に合わせる:
+//   - ヘッダ: 論理名があれば `論理名 / 物理名`、無ければ物理名。
+//   - カラム行: `名前  型  (制約)`。PK は鍵アイコン、制約は NN / U / UNN、
+//     FK は FK バッジで示す。
+//   - WithoutErd カラムは ERD 非表示なので行に出さない（DOT と同方針）。
+//
+// エッジは従来どおりテーブル単位（左=target / 右=source ハンドル）。カラム行
+// 単位へのアンカーは後続対応（#28 の残作業）。
+
+import type { JSX } from 'react'
+import { Handle, Position, type NodeProps } from 'reactflow'
+import type { Column, Table } from '../../model'
+
+export interface TableNodeData {
+  table: Table
+}
+
+// columnBadges は PK 以外の制約バッジ（NN / U / UNN / FK）を DOT と同じ規則で返す。
+// PK はアイコンで別途示すためここには含めない。
+export function columnBadges(c: Column): string[] {
+  const badges: string[] = []
+  if (!c.AllowNull && c.IsUnique) {
+    badges.push('UNN')
+  } else if (!c.AllowNull) {
+    badges.push('NN')
+  } else if (c.IsUnique) {
+    badges.push('U')
+  }
+  if (c.FK !== null) {
+    badges.push('FK')
+  }
+  return badges
+}
+
+function columnLabel(c: Column): string {
+  return c.LogicalName !== '' ? `${c.LogicalName} / ${c.Name}` : c.Name
+}
+
+function tableLabel(t: Table): string {
+  return t.LogicalName !== '' ? `${t.LogicalName} / ${t.Name}` : t.Name
+}
+
+export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
+  const { table } = data
+  const columns = table.Columns.filter((c) => !c.WithoutErd)
+
+  return (
+    <div
+      style={{
+        border: '1px solid #555',
+        borderRadius: 6,
+        background: '#fff',
+        fontSize: 12,
+        color: '#222',
+        minWidth: 160,
+        overflow: 'hidden',
+      }}
+    >
+      <Handle type="target" position={Position.Left} style={{ background: '#555' }} />
+      <div
+        style={{
+          padding: '4px 8px',
+          fontWeight: 700,
+          background: '#f2f2f2',
+          borderBottom: '1px solid #ccc',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {tableLabel(table)}
+      </div>
+      <div>
+        {columns.map((c) => {
+          const badges = columnBadges(c)
+          return (
+            <div
+              key={c.Name}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '2px 8px',
+                borderTop: '1px solid #eee',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <span style={{ width: 12, textAlign: 'center' }} aria-label={c.IsPrimaryKey ? 'primary key' : undefined}>
+                {c.IsPrimaryKey ? '🔑' : ''}
+              </span>
+              <span style={{ flex: 1 }}>{columnLabel(c)}</span>
+              <span style={{ color: '#888' }}>{c.Type}</span>
+              {badges.map((b) => (
+                <span
+                  key={b}
+                  style={{
+                    fontSize: 10,
+                    fontWeight: 600,
+                    color: '#555',
+                    background: '#eee',
+                    borderRadius: 3,
+                    padding: '0 4px',
+                  }}
+                >
+                  {b}
+                </span>
+              ))}
+            </div>
+          )
+        })}
+      </div>
+      <Handle type="source" position={Position.Right} style={{ background: '#555' }} />
+    </div>
+  )
+}

--- a/frontend/src/layout/elk.ts
+++ b/frontend/src/layout/elk.ts
@@ -21,8 +21,15 @@
 import ELK, { type ElkNode, type ElkExtendedEdge } from 'elkjs/lib/elk.bundled.js'
 import { primaryGroup, type Layout, type Schema } from '../model'
 
-const NODE_WIDTH = 200
-const NODE_HEIGHT = 100
+// テーブルノードの実寸推定に用いる定数。TableNode の描画（ヘッダ／行の高さ、
+// フォントサイズ）と概ね揃えて、カラム数の多いテーブルでも自動配置が重なり
+// にくいようにする。正確な寸法は描画後に React Flow が測るため、ここは概算でよい。
+const HEADER_HEIGHT = 28
+const ROW_HEIGHT = 22
+const CHAR_WIDTH = 7
+const H_CHROME = 44 // アイコン・バッジ・左右パディングの目安
+const MIN_NODE_WIDTH = 160
+const MAX_NODE_WIDTH = 420
 
 const ROOT_LAYOUT_OPTIONS: Record<string, string> = {
   'elk.algorithm': 'layered',
@@ -112,8 +119,30 @@ function effectiveGroupOrder(schema: Schema): string[] {
 // 復元する Layout のキーおよび Canvas / mergePositions が参照する Table.Name と
 // 一致させ、下書きで一時的に識別子規則外の名前になっても不整合が起きないように
 // する。グループ名だけは任意文字列を取り得るため sanitizeId で id 化する。
+//
+// width/height は可変高の TableNode（カラム数依存）に合わせて概算する。固定値の
+// ままだとカラムの多いテーブルで自動配置が重なるため（要件: レイアウト品質）。
 function buildTableNode(t: Schema['Tables'][number]): ElkNode {
-  return { id: t.Name, width: NODE_WIDTH, height: NODE_HEIGHT }
+  const size = estimateTableSize(t)
+  return { id: t.Name, width: size.width, height: size.height }
+}
+
+// estimateTableSize は TableNode の描画サイズを概算する。ERD 非表示カラムは
+// 行に出ないため高さに数えない。幅は最長行の文字数からの目安（正確値は描画後に
+// React Flow が測る）。
+function estimateTableSize(t: Schema['Tables'][number]): { width: number; height: number } {
+  const columns = t.Columns.filter((c) => !c.WithoutErd)
+  const height = HEADER_HEIGHT + Math.max(columns.length, 1) * ROW_HEIGHT
+
+  // 幅推定は概算のため、欠損フィールド（正規化前の疎な入力）にも頑健にする。
+  const labelLen = (name: string, logical: string | undefined): number =>
+    (logical ? logical.length + 3 : 0) + (name?.length ?? 0)
+  let maxLen = labelLen(t.Name, t.LogicalName)
+  for (const c of columns) {
+    maxLen = Math.max(maxLen, labelLen(c.Name, c.LogicalName) + (c.Type?.length ?? 0) + 4)
+  }
+  const width = Math.min(Math.max(maxLen * CHAR_WIDTH + H_CHROME, MIN_NODE_WIDTH), MAX_NODE_WIDTH)
+  return { width, height }
 }
 
 // buildEdges は全テーブルを走査して親 → 子方向の FK エッジ列を生成する。


### PR DESCRIPTION
React Flow の標準ノード（テーブル名のみ）を、**ヘッダ＋カラム行**を描くカスタムノード（`TableNode`）に置き換え、ERD ビューアとして実用的な情報量にします。表示規約は DOT レンダラ（`internal/dot`）に合わせています。

## 表示内容

- ヘッダ: `論理名 / 物理名`（論理名が無ければ物理名）
- カラム行: `名前  型  (制約)`
  - PK: 🔑 アイコン
  - 制約: `NN` / `U` / `UNN`（NOT NULL + UNIQUE）
  - FK: `FK` バッジ
- `WithoutErd` カラムは ERD 非表示なので行に出さない
- エッジは左=target / 右=source ハンドルでテーブル単位に接続

ノードが高さを持つため、#27 のグループ枠（メンバー bbox）も**測定サイズに追従**して自動で広がります。

## テスト・検証

- `columnBadges` 単体 6 件（NN/U/UNN/FK 組み合わせ、PK はアイコン扱いでバッジ非対象）
- Canvas 統合テストを新ノード形状（`data.table`）に更新
- frontend vitest 全 green / `npm run build` / `go test ./...` OK
- **実アプリ（`erdm serve`）で視覚確認**: 全テーブルのカラム・型・🔑・UNN/NN/FK バッジが描画され、グループ枠が背の高いノードを正しく包む（スクリーンショット確認済み）

## 後続（#28 の残作業）
- FK エッジを該当カラム行にアンカー（カラム行単位のハンドル）

Refs #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7aGqzkJXcfLK9eBYHp73