### PR TITLE
feat(canvas): FK エッジを該当カラム行にアンカーする（#28 完了）

### DIFF
--- a/frontend/src/components/Canvas/Canvas.test.tsx
+++ b/frontend/src/components/Canvas/Canvas.test.tsx
@@ -95,8 +95,22 @@ const SCHEMA: Schema = {
     {
       Name: 'users',
       LogicalName: '会員',
-      Columns: [],
-      PrimaryKeys: [],
+      Columns: [
+        {
+          Name: 'id',
+          LogicalName: '',
+          Type: 'bigint',
+          AllowNull: false,
+          IsUnique: true,
+          IsPrimaryKey: true,
+          Default: '',
+          Comments: [],
+          WithoutErd: false,
+          FK: null,
+          IndexRefs: [],
+        },
+      ],
+      PrimaryKeys: [0],
       Indexes: [],
       Groups: [],
     },
@@ -175,10 +189,16 @@ describe('Canvas', () => {
       id: string
       source: string
       target: string
+      sourceHandle?: string
+      targetHandle?: string
     }>
     expect(edges).toHaveLength(1)
     expect(edges[0]?.source).toBe('users')
     expect(edges[0]?.target).toBe('orders')
+    // 親側は users の PK 列（id）、子側は orders の FK 列（user_id）にアンカー。
+    // SCHEMA の users は PK 指定が無いため先頭可視列 id を採用する。
+    expect(edges[0]?.sourceHandle).toBe('s:id')
+    expect(edges[0]?.targetHandle).toBe('t:user_id')
   })
 
   it('invokes onNodeClick with the table name', () => {

--- a/frontend/src/components/Canvas/Canvas.test.tsx
+++ b/frontend/src/components/Canvas/Canvas.test.tsx
@@ -195,8 +195,8 @@ describe('Canvas', () => {
     expect(edges).toHaveLength(1)
     expect(edges[0]?.source).toBe('users')
     expect(edges[0]?.target).toBe('orders')
-    // 親側は users の PK 列（id）、子側は orders の FK 列（user_id）にアンカー。
-    // SCHEMA の users は PK 指定が無いため先頭可視列 id を採用する。
+    // 親側は users の PK 列（id: IsPrimaryKey=true）、子側は orders の FK 列
+    // （user_id）にアンカーする。
     expect(edges[0]?.sourceHandle).toBe('s:id')
     expect(edges[0]?.targetHandle).toBe('t:user_id')
   })

--- a/frontend/src/components/Canvas/Canvas.tsx
+++ b/frontend/src/components/Canvas/Canvas.tsx
@@ -34,7 +34,12 @@ import { putLayout } from '../../api'
 import type { Layout, Schema } from '../../model'
 import { GroupBoxNode } from './GroupBoxNode'
 import { GROUP_BOX_NODE_TYPE, computeGroupBoxes, isGroupBoxId } from './groupBoxes'
-import { TableNode } from './TableNode'
+import {
+  TableNode,
+  columnSourceHandleId,
+  columnTargetHandleId,
+  parentAnchorColumn,
+} from './TableNode'
 
 const SAVE_DEBOUNCE_MS = 500
 
@@ -160,15 +165,25 @@ function buildNodes(schema: Schema, layout: Layout): Node[] {
 }
 
 function buildEdges(schema: Schema): Edge[] {
+  // 親テーブルごとのアンカー列（先頭 PK 等）を事前計算する。
+  const anchorByTable = new Map<string, string | null>()
+  for (const t of schema.Tables) {
+    anchorByTable.set(t.Name, parentAnchorColumn(t))
+  }
+
   const edges: Edge[] = []
   for (const t of schema.Tables) {
     for (const c of t.Columns) {
       if (c.WithoutErd) continue
       if (c.FK === null) continue
+      // 子側は FK 列の行、親側はアンカー列（PK 行）に接続する。
+      const parentAnchor = anchorByTable.get(c.FK.TargetTable) ?? null
       edges.push({
         id: `${c.FK.TargetTable}__${t.Name}__${c.Name}`,
         source: c.FK.TargetTable,
         target: t.Name,
+        sourceHandle: parentAnchor !== null ? columnSourceHandleId(parentAnchor) : undefined,
+        targetHandle: columnTargetHandleId(c.Name),
         label: `${c.FK.CardinalityDestination}--${c.FK.CardinalitySource}`,
       })
     }

--- a/frontend/src/components/Canvas/TableNode.test.ts
+++ b/frontend/src/components/Canvas/TableNode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import type { Column } from '../../model'
-import { columnBadges } from './TableNode'
+import type { Column, Table } from '../../model'
+import { columnBadges, parentAnchorColumn } from './TableNode'
 
 function col(over: Partial<Column>): Column {
   return {
@@ -43,5 +43,30 @@ describe('columnBadges', () => {
 
   it('does not include PK (shown as an icon, not a badge)', () => {
     expect(columnBadges(col({ IsPrimaryKey: true }))).toEqual([])
+  })
+})
+
+function tbl(cols: Column[]): Table {
+  return { Name: 't', LogicalName: '', Columns: cols, PrimaryKeys: [], Indexes: [], Groups: [] }
+}
+
+describe('parentAnchorColumn', () => {
+  it('prefers the first visible primary-key column', () => {
+    const t = tbl([col({ Name: 'a' }), col({ Name: 'id', IsPrimaryKey: true })])
+    expect(parentAnchorColumn(t)).toBe('id')
+  })
+
+  it('falls back to the first visible column when there is no PK', () => {
+    const t = tbl([col({ Name: 'a' }), col({ Name: 'b' })])
+    expect(parentAnchorColumn(t)).toBe('a')
+  })
+
+  it('skips WithoutErd columns', () => {
+    const t = tbl([col({ Name: 'hidden', WithoutErd: true, IsPrimaryKey: true }), col({ Name: 'visible' })])
+    expect(parentAnchorColumn(t)).toBe('visible')
+  })
+
+  it('returns null when there are no visible columns', () => {
+    expect(parentAnchorColumn(tbl([col({ Name: 'hidden', WithoutErd: true })]))).toBeNull()
   })
 })

--- a/frontend/src/components/Canvas/TableNode.tsx
+++ b/frontend/src/components/Canvas/TableNode.tsx
@@ -17,6 +17,23 @@ export interface TableNodeData {
   table: Table
 }
 
+// カラム行のハンドル id。子側 FK 列は target（左）、親側アンカー列は source（右）。
+// source / target で型が異なるため接頭辞を分けて衝突を避ける。
+export const columnTargetHandleId = (columnName: string): string => `t:${columnName}`
+export const columnSourceHandleId = (columnName: string): string => `s:${columnName}`
+
+// parentAnchorColumn は親テーブル側でエッジを出す列名を返す。FK モデルは参照先
+// 列を持たないため、慣習に従い可視 PK の先頭列を採用する。PK が無ければ可視列の
+// 先頭、可視列が無ければ null（アンカー不能）。
+export function parentAnchorColumn(t: Table): string | null {
+  const visible = t.Columns.filter((c) => !c.WithoutErd)
+  const pk = visible.find((c) => c.IsPrimaryKey)
+  if (pk !== undefined) return pk.Name
+  return visible.length > 0 ? visible[0]!.Name : null
+}
+
+const HANDLE_STYLE = { width: 7, height: 7, background: '#7a8aa0', border: '1px solid #fff' }
+
 // columnBadges は PK 以外の制約バッジ（NN / U / UNN / FK）を DOT と同じ規則で返す。
 // PK はアイコンで別途示すためここには含めない。
 export function columnBadges(c: Column): string[] {
@@ -55,21 +72,29 @@ export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
         fontSize: 12,
         color: '#222',
         minWidth: 160,
-        overflow: 'hidden',
       }}
     >
-      <Handle type="target" position={Position.Left} style={{ background: '#555' }} />
       <div
         style={{
           padding: '4px 8px',
           fontWeight: 700,
           background: '#f2f2f2',
+          borderTopLeftRadius: 6,
+          borderTopRightRadius: 6,
           borderBottom: '1px solid #ccc',
           whiteSpace: 'nowrap',
         }}
       >
         {tableLabel(table)}
       </div>
+      {/* 可視カラムが無い縮退テーブルでもエッジが接続できるようフォールバック
+          ハンドルを用意する（通常は各カラム行のハンドルを使う）。 */}
+      {columns.length === 0 && (
+        <>
+          <Handle type="target" position={Position.Left} style={HANDLE_STYLE} />
+          <Handle type="source" position={Position.Right} style={HANDLE_STYLE} />
+        </>
+      )}
       <div>
         {columns.map((c) => {
           const badges = columnBadges(c)
@@ -77,6 +102,7 @@ export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
             <div
               key={c.Name}
               style={{
+                position: 'relative',
                 display: 'flex',
                 alignItems: 'center',
                 gap: 6,
@@ -85,6 +111,12 @@ export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
                 whiteSpace: 'nowrap',
               }}
             >
+              <Handle
+                type="target"
+                position={Position.Left}
+                id={columnTargetHandleId(c.Name)}
+                style={HANDLE_STYLE}
+              />
               {c.IsPrimaryKey ? (
                 <span role="img" aria-label="primary key" style={{ width: 12, textAlign: 'center' }}>
                   🔑
@@ -109,11 +141,16 @@ export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
                   {b}
                 </span>
               ))}
+              <Handle
+                type="source"
+                position={Position.Right}
+                id={columnSourceHandleId(c.Name)}
+                style={HANDLE_STYLE}
+              />
             </div>
           )
         })}
       </div>
-      <Handle type="source" position={Position.Right} style={{ background: '#555' }} />
     </div>
   )
 }


### PR DESCRIPTION
#28 の残作業。FK エッジの接続をテーブル単位からカラム行単位へ変更し、「どのカラム間の関係か」が一目で分かるようにします。これで #28 をクローズします。

## 変更

- **TableNode**: 各カラム行に target(左)/source(右) ハンドルを付与（id は `t:` / `s:` 接頭辞で型を区別）。可視カラム 0 件の縮退テーブル向けにノード単位のフォールバックハンドルも用意
- **parentAnchorColumn**: 親側アンカー列を決める純粋ヘルパ（可視 PK の先頭 → 無ければ可視列の先頭 → 無ければ null）
- **Canvas.buildEdges**: `sourceHandle` = 親アンカー列、`targetHandle` = 子 FK 列 を付与

## テスト・検証

- `parentAnchorColumn` 単体 4 件（PK 優先 / PK 無し / WithoutErd スキップ / 可視列なし）
- Canvas 統合: エッジの sourceHandle=`s:id` / targetHandle=`t:user_id` を検証
- frontend vitest 87 件・`npm run build`・`go test ./...` 全 green
- **実アプリ（`erdm serve`）で視覚確認**: `users.id → sessions.user_id` / `orders.user_id` が該当カラム行に接続（スクリーンショット確認済み）

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7aGqzkJXcfLK9eBYHp73