### PR TITLE
feat(canvas): secondary グループのバッジ表示とグループ強調フィルタ（#27 完了）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,9 @@ import { ApiError, getLayout, getMeta, getSchema, putSchema } from './api'
 import { Canvas } from './components/Canvas'
 import { Editor, type SaveStatus } from './components/Editor'
 import { ExportMenu } from './components/ExportMenu'
+import { GroupFilter } from './components/GroupFilter'
 import { computeLayout, mergePositions } from './layout'
-import type { Layout, Schema } from './model'
+import { allGroupNames, type Layout, type Schema } from './model'
 import { serialize } from './serializer'
 import { clearDraft, loadDraft, saveDraft } from './storage'
 
@@ -39,6 +40,8 @@ export function App(): JSX.Element {
   // エクスポートのダウンロードファイル名に使うステム名（サーバ起動元の
   // `.erdm` 由来）。取得失敗時は 'schema' にフォールバックする（issue #29）。
   const [exportBasename, setExportBasename] = useState<string>('schema')
+  // グループ強調フィルタで選択中のグループ集合（空なら強調なし、issue #27）。
+  const [highlightGroups, setHighlightGroups] = useState<Set<string>>(new Set())
 
   const draftTimerRef = useRef<number | null>(null)
   // 「直近の schema 変更がユーザー編集由来か」のフラグ。下書き復元やサーバ
@@ -165,6 +168,7 @@ export function App(): JSX.Element {
             schema={schema}
             initialLayout={layout}
             onNodeClick={handleSelectedTableNameChange}
+            highlightGroups={highlightGroups}
           />
         </ReactFlowProvider>
       </div>
@@ -195,6 +199,11 @@ export function App(): JSX.Element {
         }}
       >
         <ExportMenu basename={exportBasename} />
+        <GroupFilter
+          groups={allGroupNames(schema)}
+          highlighted={highlightGroups}
+          onChange={setHighlightGroups}
+        />
       </aside>
     </div>
   )

--- a/frontend/src/components/Canvas/Canvas.tsx
+++ b/frontend/src/components/Canvas/Canvas.tsx
@@ -34,7 +34,7 @@ import { putLayout } from '../../api'
 import type { Layout, Schema } from '../../model'
 import { GroupBoxNode } from './GroupBoxNode'
 import { GROUP_BOX_NODE_TYPE, GROUP_BOX_PREFIX, computeGroupBoxes, isGroupBoxId } from './groupBoxes'
-import { dimmedTables } from './highlight'
+import { dimmedTables, isGroupBoxDimmed } from './highlight'
 import {
   TableNode,
   columnSourceHandleId,
@@ -93,15 +93,13 @@ export function Canvas({
   // 背面に重ねて描画する。テーブルが動くと nodes が変わり枠も再計算＝追従する。
   // 強調フィルタが有効なら非該当のテーブル・グループ枠を淡色化する。
   const displayNodes = useMemo(() => {
-    const filterActive = highlightGroups.size > 0
     const boxes = computeGroupBoxes(schema, nodes).map((b) => {
       const groupName = b.id.slice(GROUP_BOX_PREFIX.length)
-      const dim = filterActive && !highlightGroups.has(groupName)
-      return withOpacity(b, dim)
+      return withOpacity(b, isGroupBoxDimmed(schema, groupName, dimmed))
     })
     const tables = nodes.map((n) => withOpacity(n, dimmed.has(n.id)))
     return [...boxes, ...tables]
-  }, [schema, nodes, dimmed, highlightGroups])
+  }, [schema, nodes, dimmed])
 
   // 端点のどちらかが淡色化されるエッジも淡色化する。
   const displayEdges = useMemo(() => {

--- a/frontend/src/components/Canvas/Canvas.tsx
+++ b/frontend/src/components/Canvas/Canvas.tsx
@@ -33,7 +33,8 @@ import 'reactflow/dist/style.css'
 import { putLayout } from '../../api'
 import type { Layout, Schema } from '../../model'
 import { GroupBoxNode } from './GroupBoxNode'
-import { GROUP_BOX_NODE_TYPE, computeGroupBoxes, isGroupBoxId } from './groupBoxes'
+import { GROUP_BOX_NODE_TYPE, GROUP_BOX_PREFIX, computeGroupBoxes, isGroupBoxId } from './groupBoxes'
+import { dimmedTables } from './highlight'
 import {
   TableNode,
   columnSourceHandleId,
@@ -42,6 +43,12 @@ import {
 } from './TableNode'
 
 const SAVE_DEBOUNCE_MS = 500
+
+// 強調フィルタで非該当ノード・エッジに与える不透明度。
+const DIM_OPACITY = 0.2
+
+// 空集合の安定参照（highlightGroups 未指定時に毎レンダー新規生成しない）。
+const EMPTY_HIGHLIGHT: ReadonlySet<string> = new Set()
 
 // テーブルノードのカスタム種別名。
 const TABLE_NODE_TYPE = 'tableNode'
@@ -60,20 +67,51 @@ export interface CanvasProps {
   // 「いま編集対象に選んだテーブル」を確定するために使う。閲覧モードのみで
   // 利用する場合は省略可能（既存の 7.5 互換）。
   onNodeClick?: (tableName: string) => void
+  // 強調フィルタで選択中のグループ集合。空/未指定なら強調なし（全表示）。
+  highlightGroups?: ReadonlySet<string>
 }
 
-export function Canvas({ schema, initialLayout, onNodeClick }: CanvasProps): JSX.Element {
+export function Canvas({
+  schema,
+  initialLayout,
+  onNodeClick,
+  highlightGroups = EMPTY_HIGHLIGHT,
+}: CanvasProps): JSX.Element {
   const initialNodes = buildNodes(schema, initialLayout)
   const initialEdges = buildEdges(schema)
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
   const debounceTimerRef = useRef<number | null>(null)
 
+  // 強調フィルタで淡色化するテーブル名集合。
+  const dimmed = useMemo(
+    () => dimmedTables(schema, new Set(highlightGroups)),
+    [schema, highlightGroups],
+  )
+
   // primary グループの背景枠を現在のテーブル配置から導出し、テーブルノードの
   // 背面に重ねて描画する。テーブルが動くと nodes が変わり枠も再計算＝追従する。
+  // 強調フィルタが有効なら非該当のテーブル・グループ枠を淡色化する。
   const displayNodes = useMemo(() => {
-    return [...computeGroupBoxes(schema, nodes), ...nodes]
-  }, [schema, nodes])
+    const filterActive = highlightGroups.size > 0
+    const boxes = computeGroupBoxes(schema, nodes).map((b) => {
+      const groupName = b.id.slice(GROUP_BOX_PREFIX.length)
+      const dim = filterActive && !highlightGroups.has(groupName)
+      return withOpacity(b, dim)
+    })
+    const tables = nodes.map((n) => withOpacity(n, dimmed.has(n.id)))
+    return [...boxes, ...tables]
+  }, [schema, nodes, dimmed, highlightGroups])
+
+  // 端点のどちらかが淡色化されるエッジも淡色化する。
+  const displayEdges = useMemo(() => {
+    if (dimmed.size === 0) return edges
+    return edges.map((e) =>
+      dimmed.has(e.source) || dimmed.has(e.target)
+        ? { ...e, style: { ...e.style, opacity: DIM_OPACITY } }
+        : e,
+    )
+  }, [edges, dimmed])
 
   // schema / initialLayout が更新されたら React Flow の state を同期する。
   // useNodesState は初期値しか拾わないため、Editor 側でテーブル追加/編集して
@@ -132,7 +170,7 @@ export function Canvas({ schema, initialLayout, onNodeClick }: CanvasProps): JSX
   return (
     <ReactFlow
       nodes={displayNodes}
-      edges={edges}
+      edges={displayEdges}
       nodeTypes={NODE_TYPES}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
@@ -145,6 +183,12 @@ export function Canvas({ schema, initialLayout, onNodeClick }: CanvasProps): JSX
       <MiniMap />
     </ReactFlow>
   )
+}
+
+// withOpacity はノードに淡色化（または解除）の style を付与した複製を返す。
+// 元 style（グループ枠の width/height 等）は保持する。
+function withOpacity(node: Node, dim: boolean): Node {
+  return { ...node, style: { ...node.style, opacity: dim ? DIM_OPACITY : 1 } }
 }
 
 function buildNodes(schema: Schema, layout: Layout): Node[] {

--- a/frontend/src/components/Canvas/TableNode.tsx
+++ b/frontend/src/components/Canvas/TableNode.tsx
@@ -90,8 +90,9 @@ export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
       >
         <span style={{ flex: 1 }}>{tableLabel(table)}</span>
         {/* secondary グループはレイアウトに影響しない（primary のみ枠になる）ため、
-            所属をノード上のバッジで示す。 */}
-        {secondaryGroups(table).map((g) => (
+            所属をノード上のバッジで示す。テーブル内でのグループ名重複
+            （@groups["a","a"] 等）は key 衝突を避けるため描画前に排除する。 */}
+        {[...new Set(secondaryGroups(table))].map((g) => (
           <span
             key={g}
             title={`group: ${g}`}

--- a/frontend/src/components/Canvas/TableNode.tsx
+++ b/frontend/src/components/Canvas/TableNode.tsx
@@ -11,7 +11,7 @@
 
 import type { JSX } from 'react'
 import { Handle, Position, type NodeProps } from 'reactflow'
-import type { Column, Table } from '../../model'
+import { type Column, type Table, secondaryGroups } from '../../model'
 
 export interface TableNodeData {
   table: Table
@@ -76,6 +76,9 @@ export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
     >
       <div
         style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
           padding: '4px 8px',
           fontWeight: 700,
           background: '#f2f2f2',
@@ -85,7 +88,26 @@ export function TableNode({ data }: NodeProps<TableNodeData>): JSX.Element {
           whiteSpace: 'nowrap',
         }}
       >
-        {tableLabel(table)}
+        <span style={{ flex: 1 }}>{tableLabel(table)}</span>
+        {/* secondary グループはレイアウトに影響しない（primary のみ枠になる）ため、
+            所属をノード上のバッジで示す。 */}
+        {secondaryGroups(table).map((g) => (
+          <span
+            key={g}
+            title={`group: ${g}`}
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              color: '#3a5',
+              background: '#e6f4ea',
+              border: '1px solid #bfe3ca',
+              borderRadius: 3,
+              padding: '0 4px',
+            }}
+          >
+            {g}
+          </span>
+        ))}
       </div>
       {/* 可視カラムが無い縮退テーブルでもエッジが接続できるようフォールバック
           ハンドルを用意する（通常は各カラム行のハンドルを使う）。 */}

--- a/frontend/src/components/Canvas/highlight.test.ts
+++ b/frontend/src/components/Canvas/highlight.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import type { Schema } from '../../model'
+import { dimmedTables } from './highlight'
+
+function table(name: string, groups: string[]): Schema['Tables'][number] {
+  return { Name: name, LogicalName: '', Columns: [], PrimaryKeys: [], Indexes: [], Groups: groups }
+}
+
+const schema: Schema = {
+  Title: 't',
+  Groups: ['auth', 'shop'],
+  Tables: [
+    table('users', ['auth']),
+    table('orders', ['shop', 'audit']), // shop=primary, audit=secondary
+    table('guests', []),
+  ],
+}
+
+describe('dimmedTables', () => {
+  it('returns empty set (no dimming) when the highlight set is empty', () => {
+    expect(dimmedTables(schema, new Set())).toEqual(new Set())
+  })
+
+  it('dims tables not belonging to any highlighted group', () => {
+    // auth を強調 → users は残り、orders / guests が淡色化。
+    expect(dimmedTables(schema, new Set(['auth']))).toEqual(new Set(['orders', 'guests']))
+  })
+
+  it('matches secondary group membership too', () => {
+    // audit は orders の secondary グループ。強調で orders は残る。
+    expect(dimmedTables(schema, new Set(['audit']))).toEqual(new Set(['users', 'guests']))
+  })
+
+  it('supports OR across multiple highlighted groups', () => {
+    expect(dimmedTables(schema, new Set(['auth', 'shop']))).toEqual(new Set(['guests']))
+  })
+})

--- a/frontend/src/components/Canvas/highlight.test.ts
+++ b/frontend/src/components/Canvas/highlight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { Schema } from '../../model'
-import { dimmedTables } from './highlight'
+import { dimmedTables, isGroupBoxDimmed } from './highlight'
 
 function table(name: string, groups: string[]): Schema['Tables'][number] {
   return { Name: name, LogicalName: '', Columns: [], PrimaryKeys: [], Indexes: [], Groups: groups }
@@ -33,5 +33,26 @@ describe('dimmedTables', () => {
 
   it('supports OR across multiple highlighted groups', () => {
     expect(dimmedTables(schema, new Set(['auth', 'shop']))).toEqual(new Set(['guests']))
+  })
+})
+
+describe('isGroupBoxDimmed', () => {
+  it('is never dimmed when the filter is inactive', () => {
+    expect(isGroupBoxDimmed(schema, 'shop', new Set())).toBe(false)
+  })
+
+  it('dims a primary box only when all its members are dimmed', () => {
+    // auth 強調時: shop の唯一の primary メンバー orders は audit 経由でなく shop
+    // なので淡色化される → shop 枠も淡色化。
+    const dimmed = dimmedTables(schema, new Set(['auth']))
+    expect(isGroupBoxDimmed(schema, 'auth', dimmed)).toBe(false)
+    expect(isGroupBoxDimmed(schema, 'shop', dimmed)).toBe(true)
+  })
+
+  it('keeps a primary box lit when a member is kept via a secondary group', () => {
+    // audit（orders の secondary）強調時: orders は残る → その primary グループ
+    // shop の枠も残す（テーブル表示と整合）。
+    const dimmed = dimmedTables(schema, new Set(['audit']))
+    expect(isGroupBoxDimmed(schema, 'shop', dimmed)).toBe(false)
   })
 })

--- a/frontend/src/components/Canvas/highlight.ts
+++ b/frontend/src/components/Canvas/highlight.ts
@@ -4,7 +4,7 @@
 // にも属さないテーブルを淡色化対象とする（primary / secondary を問わず Table.Groups
 // で判定、OR）。
 
-import type { Schema } from '../../model'
+import { primaryGroup, type Schema } from '../../model'
 
 export function dimmedTables(schema: Schema, highlight: Set<string>): Set<string> {
   const dimmed = new Set<string>()
@@ -14,4 +14,14 @@ export function dimmedTables(schema: Schema, highlight: Set<string>): Set<string
     if (!belongs) dimmed.add(t.Name)
   }
   return dimmed
+}
+
+// isGroupBoxDimmed は primary グループ枠を淡色化すべきか判定する。
+// テーブルの表示と整合させるため、その primary グループの可視メンバーが 1 つも
+// 無い（＝全員淡色化）ときのみ枠を淡色化する。secondary のみ選択でメンバーが
+// 残る場合は枠も残す。dimmed が空（フィルタ無効）なら淡色化しない。
+export function isGroupBoxDimmed(schema: Schema, groupName: string, dimmed: Set<string>): boolean {
+  if (dimmed.size === 0) return false
+  const members = schema.Tables.filter((t) => primaryGroup(t) === groupName)
+  return members.length > 0 && members.every((t) => dimmed.has(t.Name))
 }

--- a/frontend/src/components/Canvas/highlight.ts
+++ b/frontend/src/components/Canvas/highlight.ts
@@ -1,0 +1,17 @@
+// グループ強調フィルタの淡色化判定（#27）。
+//
+// highlight が空ならフィルタ無効（淡色化なし）。それ以外は、選択グループのいずれ
+// にも属さないテーブルを淡色化対象とする（primary / secondary を問わず Table.Groups
+// で判定、OR）。
+
+import type { Schema } from '../../model'
+
+export function dimmedTables(schema: Schema, highlight: Set<string>): Set<string> {
+  const dimmed = new Set<string>()
+  if (highlight.size === 0) return dimmed
+  for (const t of schema.Tables) {
+    const belongs = t.Groups.some((g) => highlight.has(g))
+    if (!belongs) dimmed.add(t.Name)
+  }
+  return dimmed
+}

--- a/frontend/src/components/GroupFilter/GroupFilter.test.tsx
+++ b/frontend/src/components/GroupFilter/GroupFilter.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GroupFilter } from './GroupFilter'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GroupFilter', () => {
+  it('renders nothing when there are no groups', () => {
+    const { container } = render(
+      <GroupFilter groups={[]} highlighted={new Set()} onChange={vi.fn()} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('lists groups with their checked state reflecting the highlight set', () => {
+    render(
+      <GroupFilter groups={['auth', 'shop']} highlighted={new Set(['shop'])} onChange={vi.fn()} />,
+    )
+    const auth = screen.getByLabelText('auth') as HTMLInputElement
+    const shop = screen.getByLabelText('shop') as HTMLInputElement
+    expect(auth.checked).toBe(false)
+    expect(shop.checked).toBe(true)
+  })
+
+  it('adds a group to the highlight set when toggled on', () => {
+    const onChange = vi.fn()
+    render(<GroupFilter groups={['auth', 'shop']} highlighted={new Set()} onChange={onChange} />)
+    screen.getByLabelText('auth').click()
+    expect(onChange).toHaveBeenCalledWith(new Set(['auth']))
+  })
+
+  it('removes a group from the highlight set when toggled off', () => {
+    const onChange = vi.fn()
+    render(
+      <GroupFilter groups={['auth', 'shop']} highlighted={new Set(['auth'])} onChange={onChange} />,
+    )
+    screen.getByLabelText('auth').click()
+    expect(onChange).toHaveBeenCalledWith(new Set())
+  })
+
+  it('clears all highlights via the Clear button', () => {
+    const onChange = vi.fn()
+    render(
+      <GroupFilter
+        groups={['auth', 'shop']}
+        highlighted={new Set(['auth', 'shop'])}
+        onChange={onChange}
+      />,
+    )
+    screen.getByRole('button', { name: 'Clear' }).click()
+    expect(onChange).toHaveBeenCalledWith(new Set())
+  })
+})

--- a/frontend/src/components/GroupFilter/GroupFilter.tsx
+++ b/frontend/src/components/GroupFilter/GroupFilter.tsx
@@ -1,0 +1,62 @@
+// グループフィルタ: サイドバーで特定グループを選び、キャンバス上で該当グループの
+// テーブルを強調（非該当を淡色化）する（#27）。
+//
+// 選択が空のときはフィルタ無効（全テーブル通常表示）。複数選択はいずれかに属する
+// テーブルを強調する（OR）。primary / secondary を問わず、テーブルの所属グループ
+// （Table.Groups）で判定する。
+
+import type { JSX } from 'react'
+
+export interface GroupFilterProps {
+  // 選択肢となる全グループ名（初出順）。
+  groups: string[]
+  // 現在強調中のグループ集合。空なら強調なし。
+  highlighted: Set<string>
+  onChange: (next: Set<string>) => void
+}
+
+export function GroupFilter({ groups, highlighted, onChange }: GroupFilterProps): JSX.Element | null {
+  if (groups.length === 0) {
+    return null
+  }
+
+  const toggle = (name: string): void => {
+    const next = new Set(highlighted)
+    if (next.has(name)) {
+      next.delete(name)
+    } else {
+      next.add(name)
+    }
+    onChange(next)
+  }
+
+  return (
+    <section
+      aria-label="Group filter"
+      style={{ borderTop: '1px solid #ccc', marginTop: '8px', paddingTop: '8px' }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h3 style={{ fontSize: '13px', margin: '0 0 4px' }}>Groups</h3>
+        {highlighted.size > 0 && (
+          <button
+            type="button"
+            onClick={() => onChange(new Set())}
+            style={{ fontSize: '11px' }}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {groups.map((g) => (
+          <li key={g}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px' }}>
+              <input type="checkbox" checked={highlighted.has(g)} onChange={() => toggle(g)} />
+              {g}
+            </label>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/components/GroupFilter/index.tsx
+++ b/frontend/src/components/GroupFilter/index.tsx
@@ -1,0 +1,2 @@
+// グループフィルタ UI（#27）。選択グループのテーブルを強調する。
+export { GroupFilter, type GroupFilterProps } from './GroupFilter'

--- a/frontend/src/model/groups.test.ts
+++ b/frontend/src/model/groups.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { allGroupNames, primaryGroup, secondaryGroups } from './groups'
+import type { Schema, Table } from './types'
+
+function table(name: string, groups: string[]): Table {
+  return { Name: name, LogicalName: '', Columns: [], PrimaryKeys: [], Indexes: [], Groups: groups }
+}
+
+describe('primaryGroup / secondaryGroups', () => {
+  it('splits Groups into primary (first) and secondary (rest)', () => {
+    const t = table('t', ['core', 'audit', 'ops'])
+    expect(primaryGroup(t)).toBe('core')
+    expect(secondaryGroups(t)).toEqual(['audit', 'ops'])
+  })
+
+  it('returns null / empty for an ungrouped table', () => {
+    const t = table('t', [])
+    expect(primaryGroup(t)).toBeNull()
+    expect(secondaryGroups(t)).toEqual([])
+  })
+})
+
+describe('allGroupNames', () => {
+  it('lists Schema.Groups first, then table-discovered groups, deduped in first-seen order', () => {
+    const schema: Schema = {
+      Title: 't',
+      Groups: ['auth', 'shop'],
+      Tables: [
+        table('users', ['auth', 'audit']), // audit は Schema.Groups 未登録
+        table('orders', ['shop']),
+      ],
+    }
+    expect(allGroupNames(schema)).toEqual(['auth', 'shop', 'audit'])
+  })
+
+  it('returns an empty list when there are no groups', () => {
+    expect(allGroupNames({ Title: 't', Groups: [], Tables: [table('a', [])] })).toEqual([])
+  })
+})

--- a/frontend/src/model/groups.ts
+++ b/frontend/src/model/groups.ts
@@ -6,7 +6,7 @@
 //   - 2 要素目以降が secondary グループ。
 //   - primary グループのみが cluster / groupNode 描画の単位になる。
 
-import type { Table } from './types'
+import type { Schema, Table } from './types'
 
 // primaryGroup は Table の primary グループ名を返す。未所属なら null。
 export function primaryGroup(t: Table): string | null {
@@ -16,4 +16,23 @@ export function primaryGroup(t: Table): string | null {
 // secondaryGroups は secondary グループ名（Groups の 2 要素目以降）を返す。
 export function secondaryGroups(t: Table): string[] {
   return t.Groups.length > 1 ? t.Groups.slice(1) : []
+}
+
+// allGroupNames はスキーマに現れる全グループ名を重複なく初出順で返す
+// （Schema.Groups を先頭に、テーブルの Groups で発見した未登録分を末尾へ）。
+// フィルタ UI の選択肢に用いる。
+export function allGroupNames(schema: Schema): string[] {
+  const seen = new Set<string>()
+  const order: string[] = []
+  const add = (name: string): void => {
+    if (!seen.has(name)) {
+      seen.add(name)
+      order.push(name)
+    }
+  }
+  for (const name of schema.Groups) add(name)
+  for (const t of schema.Tables) {
+    for (const g of t.Groups) add(g)
+  }
+  return order
 }


### PR DESCRIPTION
#27 の残作業。primary グループは枠で可視化済みでしたが、secondary グループはどこにも現れていませんでした。secondary バッジ + グループ強調フィルタを追加し、#27 をクローズします。

## 変更

- **TableNode**: secondary グループ名をヘッダのバッジ（緑系）で表示
- **GroupFilter**（新規サイドバー UI）: 全グループのチェックボックス一覧 + Clear。選択が空なら強調なし
- **Canvas**: `highlightGroups` を受け取り、非該当のテーブル・グループ枠・エッジを淡色化（opacity 0.2）。primary/secondary を問わず `Table.Groups` で判定（OR）
- **model**: `allGroupNames`（全グループ名を初出順で列挙）
- **App**: フィルタ状態を保持し GroupFilter と Canvas を配線

## テスト・検証

- `dimmedTables` 単体 4 件（空=強調なし / primary / secondary / OR）
- `allGroupNames` 単体、`GroupFilter` 5 件（描画・トグル・Clear）
- frontend vitest 100 件・`npm run build`・`go test ./...` 全 green
- **実アプリ（`erdm serve`）で視覚確認**: orders の "audit" バッジ表示、auth 選択で auth グループのみ通常表示・他は淡色化（スクリーンショット確認済み）

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7aGqzkJXcfLK9eBYHp73