### PR TITLE
fix(introspect): PG 配列型で要素の長さ/精度修飾子を保持する

### DIFF
--- a/internal/introspect/postgres.go
+++ b/internal/introspect/postgres.go
@@ -277,6 +277,25 @@ func applyPGTypeModifier(typ string, charLen, numPrec, numScale, dtPrec sql.Null
 	return base + mod
 }
 
+// insertArrayElementModifier は配列型表記（末尾 `[]`）の要素型へ修飾子を挿入する
+// 純粋関数。mod は括弧内の文字列（例 "64" / "10,2"）。
+//
+//   - `varchar[]`  + "64"    → `varchar(64)[]`
+//   - `numeric[]`  + "10,2"  → `numeric(10,2)[]`
+//
+// typ が `[]` で終わらない、あるいは既に括弧付き（`varchar(64)[]` 等）の場合は
+// 二重付与を避けてそのまま返す。mod が空なら何もしない。
+func insertArrayElementModifier(typ, mod string) string {
+	if mod == "" || !strings.HasSuffix(typ, "[]") {
+		return typ
+	}
+	base := strings.TrimSuffix(typ, "[]")
+	if strings.Contains(base, "(") {
+		return typ
+	}
+	return base + "(" + mod + ")[]"
+}
+
 // pgTypeModifierFor は基底型名（配列の `[]` を剥がした後）に対して付与すべき
 // 修飾子文字列を返す。修飾子が不要な場合は空文字列を返す。
 func pgTypeModifierFor(base string, charLen, numPrec, numScale, dtPrec sql.NullInt64) string {

--- a/internal/introspect/postgres_queries.go
+++ b/internal/introspect/postgres_queries.go
@@ -81,6 +81,29 @@ WHERE c.table_schema = $1
 ORDER BY c.table_name, c.ordinal_position
 `
 
+// sqlSelectPGArrayElementModifiers は配列カラムの要素型修飾子（`varchar(64)[]` の
+// `64`、`numeric(10,2)[]` の `10,2` 等）を取得する SELECT 文。
+//
+// PostgreSQL の `information_schema.element_types` は配列要素の base 型は返すが
+// 長さ・精度（typmod）を NULL にする仕様のため、そこからは復元できない。
+// `pg_catalog.format_type(atttypid, atttypmod)` は `character varying(64)[]` の
+// ように修飾子込みの正準表記を返すので、その先頭の括弧内文字列を要素修飾子として
+// 取り出す。デフォルト typmod（例: `timestamp` の精度 6）は format_type が省くため、
+// 既存の「既定値は出力しない」方針とも自然に一致する。配列以外・修飾子なし配列は
+// 対象外（本 map に載らず、既存の型解決がそのまま使われる）。
+const sqlSelectPGArrayElementModifiers = `
+SELECT c.relname, a.attname,
+       substring(format_type(a.atttypid, a.atttypmod) from '\(([^)]*)\)') AS element_modifier
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = $1
+  AND c.relkind IN ('r', 'p')
+  AND a.attnum > 0 AND NOT a.attisdropped
+  AND format_type(a.atttypid, a.atttypmod) LIKE '%[]'
+  AND substring(format_type(a.atttypid, a.atttypmod) from '\(([^)]*)\)') IS NOT NULL
+`
+
 // sqlSelectPGColumnComments はカラムコメントを `pg_description` から取得する
 // SELECT 文（要件 8.1）。
 //
@@ -284,6 +307,10 @@ func selectPGTableComments(ctx context.Context, tx *sql.Tx, schema string) (map[
 // 単一カラム UNIQUE 性は別段で `applySingleColumnUnique`／単一カラム UNIQUE 制約
 // のマージで補完される（取得段階では UNIQUE 性は未確定）。
 func selectPGColumns(ctx context.Context, tx *sql.Tx, schema string) (map[string][]rawColumn, error) {
+	arrayMods, err := selectPGArrayElementModifiers(ctx, tx, schema)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := tx.QueryContext(ctx, sqlSelectPGColumns, schema)
 	if err != nil {
 		return nil, fmt.Errorf("introspect/postgres: select columns: %w", err)
@@ -299,6 +326,13 @@ func selectPGColumns(ctx context.Context, tx *sql.Tx, schema string) (map[string
 		typ, defOut := normalizePGSerial(r.DataType, r.Default)
 		typ = resolvePGType(typ, r.UDTName)
 		typ = applyPGTypeModifier(typ, r.CharMaxLength, r.NumPrecision, r.NumScale, r.DTPrecision)
+		// 配列カラムは information_schema からは要素修飾子が得られないため、
+		// pg_catalog 由来の修飾子（あれば）を要素型へ付与する。
+		if r.DataType == "ARRAY" {
+			if mod := arrayMods[tableColumnKey{Table: r.Table, Column: r.Name}]; mod != "" {
+				typ = insertArrayElementModifier(typ, mod)
+			}
+		}
 		out[r.Table] = append(out[r.Table], rawColumn{
 			Name:    r.Name,
 			Type:    typ,
@@ -308,6 +342,30 @@ func selectPGColumns(ctx context.Context, tx *sql.Tx, schema string) (map[string
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("introspect/postgres: select columns: rows: %w", err)
+	}
+	return out, nil
+}
+
+// selectPGArrayElementModifiers は (table, column) -> 要素修飾子（括弧内文字列、
+// 例 "64" / "10,2"）の map を返す。配列でない／修飾子の無いカラムは含まれない。
+func selectPGArrayElementModifiers(ctx context.Context, tx *sql.Tx, schema string) (map[tableColumnKey]string, error) {
+	rows, err := tx.QueryContext(ctx, sqlSelectPGArrayElementModifiers, schema)
+	if err != nil {
+		return nil, fmt.Errorf("introspect/postgres: select array modifiers: %w", err)
+	}
+	defer rows.Close()
+	out := map[tableColumnKey]string{}
+	for rows.Next() {
+		var tbl, col, mod string
+		if err := rows.Scan(&tbl, &col, &mod); err != nil {
+			return nil, fmt.Errorf("introspect/postgres: select array modifiers: scan: %w", err)
+		}
+		if mod != "" {
+			out[tableColumnKey{Table: tbl, Column: col}] = mod
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("introspect/postgres: select array modifiers: rows: %w", err)
 	}
 	return out, nil
 }

--- a/internal/introspect/postgres_test.go
+++ b/internal/introspect/postgres_test.go
@@ -333,6 +333,27 @@ func TestApplyFKSourceUnique(t *testing.T) {
 
 // markColumnUnique は最初に一致したカラムにだけ IsUnique=true を立て、
 // 同名カラムが無い場合は何もしない（防御的に panic しない）。
+func TestInsertArrayElementModifier(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		typ  string
+		mod  string
+		want string
+	}{
+		{"varchar[]", "64", "varchar(64)[]"},
+		{"numeric[]", "10,2", "numeric(10,2)[]"},
+		{"integer[]", "", "integer[]"},           // 修飾子なしは不変
+		{"varchar(64)[]", "64", "varchar(64)[]"}, // 既に括弧付きなら二重付与しない
+		{"varchar", "64", "varchar"},             // 配列でなければ不変
+		{"text[]", "", "text[]"},
+	}
+	for _, c := range cases {
+		if got := insertArrayElementModifier(c.typ, c.mod); got != c.want {
+			t.Errorf("insertArrayElementModifier(%q, %q) = %q, want %q", c.typ, c.mod, got, c.want)
+		}
+	}
+}
+
 func TestMarkColumnUnique(t *testing.T) {
 	t.Parallel()
 	cols := []rawColumn{{Name: "a"}, {Name: "b"}}
@@ -419,6 +440,11 @@ func TestPGSQLConstantsCarryRequiredKeywords(t *testing.T) {
 			name: "column comments",
 			sql:  sqlSelectPGColumnComments,
 			want: []string{"pg_attribute", "pg_description", "attisdropped"},
+		},
+		{
+			name: "array element modifiers",
+			sql:  sqlSelectPGArrayElementModifiers,
+			want: []string{"format_type", "pg_attribute", "'%[]'", "substring"},
 		},
 		{
 			name: "primary keys",


### PR DESCRIPTION
#32（CI 実 DB テスト有効化）の作業中に、実 PostgreSQL に対して統合テストを走らせて**発見した実バグ**の修正です。

## 症状

`erdm import` で `varchar(64)[]` / `numeric(10,2)[]` が `varchar[]` / `numeric[]` に劣化する（配列要素の長さ・精度が欠落）。

## 根本原因

PostgreSQL の `information_schema.element_types` は配列要素の **base 型は返すが typmod（長さ・精度）を NULL** にする仕様。既存実装はここから要素修飾子を得ようとしていたため原理的に復元できなかった。

```
-- element_types は varchar(64)[] の要素長を NULL で返す
object_name | collection_type_identifier | data_type         | character_maximum_length
dbg_arr     | 2                          | character varying | (null)
```

## 修正

`pg_catalog.format_type(atttypid, atttypmod)` は `character varying(64)[]` のように修飾子込みの正準表記を返す。その先頭括弧内文字列（`64` / `10,2`）を要素修飾子として取り出し、配列カラムの要素型へ付与する。`format_type` は既定 typmod を省くため「既定値は出力しない」既存方針とも自然に一致。

- 追加クエリ `selectPGArrayElementModifiers`（配列かつ修飾子ありのみ）
- `insertArrayElementModifier`（純粋関数、単体テスト付き）
- **既存の information_schema 経路・非配列型の解決は完全に不変（回帰ゼロ）**

## 検証

- ローカルの実 PostgreSQL（docker）に対し統合テスト全件パス（`TestIntegration_Postgres_ArrayTypes` を含む）
- `go test ./...`（統合はスキップ）全パス

CI での自動実行は後続の #32 で有効化します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7aGqzkJXcfLK9eBYHp73