### PR TITLE
ci: introspect の実 DB 統合テストを CI で実行する（#32）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,42 @@ jobs:
         run: make build
       - name: Test
         run: make test
+
+  # introspect（erdm import）の実 DB 統合テストを PostgreSQL / MySQL の
+  # サービスコンテナに対して実行する。SQLite は Docker 不要で常時走る。
+  # 統合テストは環境変数 DSN が設定されているときのみ有効になる（#32）。
+  integration:
+    runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Tokyo
+      ERDM_TEST_POSTGRES_DSN: postgres://erdm:erdm@localhost:5432/erdm_test?sslmode=disable
+      ERDM_TEST_MYSQL_DSN: erdm:erdm@tcp(localhost:3306)/erdm_test?parseTime=true
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: erdm
+          POSTGRES_PASSWORD: erdm
+          POSTGRES_DB: erdm_test
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready -U erdm -d erdm_test" --health-interval=10s --health-timeout=5s --health-retries=10
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: erdm_test
+          MYSQL_USER: erdm
+          MYSQL_PASSWORD: erdm
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot" --health-interval=10s --health-timeout=5s --health-retries=15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      # introspect パッケージは PEG 生成物・フロント埋め込みに依存しないため、
+      # make build は不要。統合テストのみを直接実行する。
+      - name: Integration tests (introspect, real DB)
+        run: go test -v -run Integration ./internal/introspect/...


### PR DESCRIPTION
`erdm import`（introspect）の実 DB 統合テストを CI で自動実行します。従来は `ERDM_TEST_{POSTGRES,MYSQL}_DSN` 未設定で常にスキップされ、実クエリ実行・行スキャン経路が CI で一切検証されていませんでした。

## 変更

- `integration` ジョブを追加し、`postgres:16` / `mysql:8` を **service コンテナ**で起動（health-check 付き）
- `ERDM_TEST_POSTGRES_DSN` / `ERDM_TEST_MYSQL_DSN` を注入
- SQLite は Docker 不要で常時実行
- introspect パッケージは PEG 生成物・フロント埋め込みに非依存のため `make build` 不要 → `go test -run Integration ./internal/introspect/...` を直接実行（軽量）

## 検証

- **ローカルの実 PostgreSQL / MySQL（docker）に対し、CI と同一の DSN 形式・同一コマンドで統合テスト全件パスを確認**
- 本 CI 有効化の作業中に **PG 配列型の要素修飾子欠落バグを発見し修正済み**（PR #42、マージ済み）。これは #32 を進めた直接の成果

## 補足

この PR がマージされると、以後 introspect の実 DB 回帰が CI で自動検出されます。

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7aGqzkJXcfLK9eBYHp73